### PR TITLE
Include header files whose declarations are used

### DIFF
--- a/include/souper/SMTLIB2/Solver.h
+++ b/include/souper/SMTLIB2/Solver.h
@@ -17,7 +17,9 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/system_error.h"
+#include <functional>
 #include <memory>
+#include <vector>
 
 namespace souper {
 


### PR DESCRIPTION
The xcode clang compiler on Mac requires these

I electronically signed the CLA. Might not have been processed yet.
