### PR TITLE
Link against clang/llvm as late as possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,18 +133,13 @@ set_target_properties(souperClangTool clang-souper
 set_target_properties(extractor_tests inst_tests
   PROPERTIES COMPILE_FLAGS "${GTEST_CXXFLAGS} ${LLVM_CXXFLAGS} -Wno-covered-switch-default")
 
-# Libraries
-target_link_libraries(souperClangTool souperExtractor souperTool)
-target_link_libraries(souperExtractor souperInst kleeExpr)
-target_link_libraries(souperTool souperExtractor souperSMTLIB2)
-
 # Executables
-target_link_libraries(souper souperExtractor souperSMTLIB2 souperTool ${LLVM_LDFLAGS} ${LLVM_LIBS})
-target_link_libraries(clang-souper souperClangTool souperExtractor souperSMTLIB2 souperTool ${LLVM_LDFLAGS} ${CLANG_LIBS} ${LLVM_LIBS})
+target_link_libraries(souper souperTool souperExtractor souperInst souperSMTLIB2 kleeExpr ${LLVM_LDFLAGS} ${LLVM_LIBS})
+target_link_libraries(clang-souper souperClangTool souperTool souperExtractor souperInst souperSMTLIB2 kleeExpr ${CLANG_LIBS} ${LLVM_LIBS} ${LLVM_LDFLAGS})
 
 # Tests
 target_link_libraries(internal-solver-test souperSMTLIB2 ${LLVM_LDFLAGS} ${LLVM_LIBS})
-target_link_libraries(extractor_tests souperExtractor ${GTEST_LIBS} ${LLVM_LDFLAGS} ${LLVM_LIBS})
+target_link_libraries(extractor_tests souperExtractor souperInst kleeExpr ${GTEST_LIBS} ${LLVM_LDFLAGS} ${LLVM_LIBS})
 target_link_libraries(inst_tests souperInst ${GTEST_LIBS} ${LLVM_LDFLAGS} ${LLVM_LIBS})
 
 # Custom targets


### PR DESCRIPTION
This allows the static libraries to be linked into an dynamic llvm compiler pass library without causing runtime link errors on Mac OS X due to doubly defined symbols.

Unfortunately, I can currently _only_ test on Mac OS X, where this works. Hence, this needs to be tested on Linux before being committed.

I dropped the target_link_libraries that were not depending on any other libraries; maybe those should have been kept. I happily update the patch if this is required.
