### PR TITLE
add in-memory caching using a proxy Solver class that intercepts solver ...

### DIFF
--- a/include/souper/Extractor/CandidateMap.h
+++ b/include/souper/Extractor/CandidateMap.h
@@ -44,9 +44,6 @@ struct CandidateMapEntry {
   unsigned Priority;
 
   void print(llvm::raw_ostream &OS) const;
-
-  /// Return the SMT-LIB2 query for this candidate.
-  std::string getQuery() const;
 };
 
 /// Map from candidate string representations to candidate information.

--- a/include/souper/Extractor/KLEEBuilder.h
+++ b/include/souper/Extractor/KLEEBuilder.h
@@ -29,8 +29,11 @@ struct CandidateExpr {
   klee::ref<klee::Expr> E;
 };
 
-CandidateExpr GetCandidateExprForReplacement(const CandidateReplacement &CR);
+CandidateExpr GetCandidateExprForReplacement(const std::vector<InstMapping> &PCs,
+                                             InstMapping Mapping);
 bool IsTriviallyInvalid(klee::ref<klee::Expr> E);
+std::string BuildQuery(const std::vector<InstMapping> &PCs,
+                       InstMapping Mapping);
 
 }
 

--- a/include/souper/Extractor/Solver.h
+++ b/include/souper/Extractor/Solver.h
@@ -17,6 +17,7 @@
 
 #include <vector>
 #include "llvm/Support/system_error.h"
+#include "souper/Extractor/CandidateMap.h"
 #include "souper/Extractor/Candidates.h"
 #include "souper/SMTLIB2/Solver.h"
 
@@ -27,6 +28,7 @@ public:
   virtual ~Solver();
   virtual llvm::error_code isValid(const std::vector<InstMapping> &PCs,
                                    InstMapping Mapping, bool &IsValid) = 0;
+  virtual std::string getName() = 0;
 };
 
 std::unique_ptr<Solver> createBaseSolver(

--- a/include/souper/Tool/CandidateMapUtils.h
+++ b/include/souper/Tool/CandidateMapUtils.h
@@ -17,6 +17,7 @@
 
 #include "llvm/Support/raw_ostream.h"
 #include "souper/Extractor/CandidateMap.h"
+#include "souper/Extractor/Solver.h"
 
 namespace llvm {
 
@@ -32,7 +33,7 @@ void AddModuleToCandidateMap(InstContext &IC, ExprBuilderContext &EBC,
                              CandidateMap &CandMap, llvm::Module *M);
 
 bool SolveCandidateMap(llvm::raw_ostream &OS, const CandidateMap &M,
-                       SMTLIBSolver *Solver);
+                       Solver *Solver);
 
 }
 

--- a/lib/Tool/CandidateMapUtils.cpp
+++ b/lib/Tool/CandidateMapUtils.cpp
@@ -32,19 +32,21 @@ void souper::AddModuleToCandidateMap(InstContext &IC, ExprBuilderContext &EBC,
   }
 }
 
-bool souper::SolveCandidateMap(llvm::raw_ostream &OS, const CandidateMap &M,
-                               SMTLIBSolver *Solver) {
-  if (Solver) {
+namespace souper {
+
+bool SolveCandidateMap(llvm::raw_ostream &OS, const CandidateMap &M,
+                       Solver *S) {
+  if (S) {
     OS << "; Listing valid replacements.\n";
-    OS << "; Using solver: " << Solver->getName() << '\n';
+    OS << "; Using solver: " << S->getName() << '\n';
     for (const auto &Cand : M) {
-      bool Sat;
-      if (llvm::error_code EC =
-              Solver->isSatisfiable(Cand.second.getQuery(), Sat)) {
+      bool Valid;
+      if (llvm::error_code EC = S->isValid(Cand.second.PCs,
+                                           Cand.second.Mapping, Valid)) {
         llvm::errs() << "Unable to query solver: " << EC.message() << '\n';
         return false;
       }
-      if (!Sat) {
+      if (Valid) {
         OS << '\n';
         Cand.second.print(OS);
       }
@@ -58,4 +60,6 @@ bool souper::SolveCandidateMap(llvm::raw_ostream &OS, const CandidateMap &M,
   }
 
   return true;
+}
+
 }

--- a/tools/clang-souper.cpp
+++ b/tools/clang-souper.cpp
@@ -69,6 +69,6 @@ int main(int argc, const char **argv) {
       getGlobalContext(), IC, EBC, OwnedMods, CandMap));
   Tool.run(Factory.get());
 
-  std::unique_ptr<SMTLIBSolver> Solver = GetSolverFromArgs();
-  return SolveCandidateMap(llvm::outs(), CandMap, Solver.get()) ? 0 : 1;
+  std::unique_ptr<Solver> S = GetSolverFromArgs();
+  return SolveCandidateMap(llvm::outs(), CandMap, S.get()) ? 0 : 1;
 }

--- a/tools/souper.cpp
+++ b/tools/souper.cpp
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  std::unique_ptr<SMTLIBSolver> Solver = GetSolverFromArgs();
+  std::unique_ptr<Solver> S = GetSolverFromArgs();
 
   InstContext IC;
   ExprBuilderContext EBC;
@@ -96,5 +96,5 @@ int main(int argc, char **argv) {
 
   AddModuleToCandidateMap(IC, EBC, CandMap, M.get());
 
-  return SolveCandidateMap(llvm::outs(), CandMap, Solver.get()) ? 0 : 1;
+  return SolveCandidateMap(llvm::outs(), CandMap, S.get()) ? 0 : 1;
 }

--- a/unittests/Extractor/ExtractorTests.cpp
+++ b/unittests/Extractor/ExtractorTests.cpp
@@ -59,7 +59,7 @@ struct ExtractorTest : testing::Test {
     for (auto &B : CS.Blocks) {
       for (auto &R : B->Replacements) {
         std::unique_ptr<CandidateExpr> CE(
-            new CandidateExpr(GetCandidateExprForReplacement(R)));
+            new CandidateExpr(GetCandidateExprForReplacement(R.PCs, R.Mapping)));
         if (!IsTriviallyInvalid(CE->E)) {
           CandExprs.emplace_back(std::move(CE));
         }


### PR DESCRIPTION
...requests

and, if the Souper IR has been seen before, answers with the cached result;
there tend to be a lot of hits when Souper is run as an LLVM pass since we're
called multiple times with very similar code

also some associated refactoring: Pass no longer sees CandidateMapEntries, and
the CandidateMapEntry::getQuery() method is gone with its code moved into a new
BuildQuery() function
