### PR TITLE
fix null pointer crash

### DIFF
--- a/include/souper/Tool/GetSolverFromArgs.h
+++ b/include/souper/Tool/GetSolverFromArgs.h
@@ -66,7 +66,9 @@ static llvm::cl::opt<bool> Cache(
   llvm::cl::init(false));
 
 static std::unique_ptr<Solver> GetSolverFromArgs() {
-  std::unique_ptr<Solver> S = createBaseSolver (GetUnderlyingSolverFromArgs(), 0);
+  std::unique_ptr<SMTLIBSolver> US = GetUnderlyingSolverFromArgs();
+  if (!US) return NULL;
+  std::unique_ptr<Solver> S = createBaseSolver (std::move(US), 0);
   if (Cache) {
     return createCachingSolver (std::move(S));
   } else {


### PR DESCRIPTION
Souper was crashing when invoked like this:

  souper foo.bc

The problem was that when the solver command line argument was missing, a Solver
object with a NULL BaseSolver was getting created, crashing later on. The fix is
to avoid creating the Solver and just return NULL when we don't have a
BaseSolver.
