### PR TITLE
Bugfix: Extend/Truncate Ptr instruction to PSize

### DIFF
--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -107,6 +107,7 @@ Inst *ExprBuilder::buildGEP(Inst *Ptr, gep_type_iterator begin,
       Index = IC.getInst(Inst::SExt, PSize, {Index});
       Inst *Addend = IC.getInst(
           Inst::Mul, PSize, {Index, IC.getConst(APInt(PSize, ElementSize))});
+      Ptr = IC.getInst(Inst::SExt, PSize, {Ptr});
       Ptr = IC.getInst(Inst::Add, PSize, {Ptr, Addend});
     }
   }


### PR DESCRIPTION
This fix addresses the issues #29 and #33. The Addend instruction is of PSize width, but the Ptr instruction can have a different width that is not checked before passing it to Inst::Add. This was the source of the size mismatches when building KLEE expressions.
