### PR TITLE
Ignore VectorType GetElementPtrInst (issues #29, #33)

### DIFF
--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -277,6 +277,8 @@ Inst *ExprBuilder::build(Value *V) {
       ; // fallthrough to return below
     }
   } else if (auto GEP = dyn_cast<GetElementPtrInst>(V)) {
+    if (isa<VectorType>(GEP->getType()))
+      return makeArrayRead(V); // vector operation
     return buildGEP(get(GEP->getOperand(0)), gep_type_begin(GEP),
                     gep_type_end(GEP));
   } else if (auto Phi = dyn_cast<PHINode>(V)) {

--- a/test/Solver/vector-gep.ll
+++ b/test/Solver/vector-gep.ll
@@ -1,0 +1,24 @@
+
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+%class.x0 = type { i32*, i32* }
+@x3 = global %class.x0 zeroinitializer, align 16
+
+define i1 @foo() #0 {
+entry:
+  %0 = load <2 x i32*>* bitcast (%class.x0* @x3 to <2 x i32*>*), align 16
+  %1 = getelementptr <2 x i32*> %0, <2 x i64> <i64 1, i64 1>
+  store <2 x i32*> %1, <2 x i32*>* bitcast (%class.x0* @x3 to <2 x i32*>*), align 16
+  %2 = ptrtoint <2 x i32*> %1 to <2 x i64>
+  %3 = bitcast <2 x i64> %2 to i128
+  %trunc = trunc i128 %3 to i64
+  %res = icmp eq i64 %trunc, 0
+  ret i1 %res
+}
+
+!0 = metadata !{ i1 0 }


### PR DESCRIPTION
The test case contains fragments from #29 and has merely one goal: execute a `getelementptr` instruction of `VectorType`.
