### PR TITLE
Don't create SExt insts of equal width

### DIFF
--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -279,7 +279,12 @@ Inst *ExprBuilder::build(Value *V) {
     case Instruction::SExt:
       if (!isa<IntegerType>(Cast->getType()))
         break; // could be a vector operation
-      return IC.getInst(Inst::SExt, DestSize, {Op});
+      if (Op->Width > DestSize)
+        return IC.getInst(Inst::Trunc, DestSize, {Op});
+      else if (Op->Width < DestSize)
+        return IC.getInst(Inst::SExt, DestSize, {Op});
+      else
+        return Op;
 
     case Instruction::Trunc:
       if (!isa<IntegerType>(Cast->getType()))


### PR DESCRIPTION
Currently, souper still generates `sext` instructions as follows:

`%7:i64 = sext 0:i64`

Consequently, souper parser doesn't pass the sanity checks when parsing such instructions. The proposed patch eliminates the creation of such instructions. Is a test case necessary in this case?
