### PR TITLE
bump Klee version, LLVM version, Hiredis version, build and install only the static hiredis lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,5 @@ add_library(profileRuntime STATIC
 
 set(SOUPER_PASS ${CMAKE_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}souperPass${CMAKE_SHARED_LIBRARY_SUFFIX})
 set(PROFILE_LIBRARY ${CMAKE_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}profileRuntime${CMAKE_STATIC_LIBRARY_SUFFIX})
-# this can be prettier once find_library() has a way to prefer static libraries
-set(HIREDIS_STATIC_LIBRARY ${CMAKE_SOURCE_DIR}/third_party/hiredis/install/lib/${CMAKE_STATIC_LIBRARY_PREFIX}hiredis${CMAKE_STATIC_LIBRARY_SUFFIX})
 configure_file(${CMAKE_SOURCE_DIR}/utils/sclang.in ${CMAKE_BINARY_DIR}/sclang @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/utils/sclang.in ${CMAKE_BINARY_DIR}/sclang++ @ONLY)

--- a/lib/Extractor/KLEEBuilder.cpp
+++ b/lib/Extractor/KLEEBuilder.cpp
@@ -646,7 +646,8 @@ bool souper::IsTriviallyInvalid(ref<Expr> E) {
 std::string souper::BuildQuery(const std::vector<InstMapping> &PCs,
                                InstMapping Mapping,
                                std::vector<Inst *> *ModelVars) {
-  std::ostringstream SMTSS;
+  std::string SMTStr;
+  llvm::raw_string_ostream SMTSS(SMTStr);
   ConstraintManager Manager;
   CandidateExpr CE = GetCandidateExprForReplacement(PCs, Mapping);
   Query KQuery(Manager, CE.E);
@@ -671,7 +672,7 @@ std::string souper::BuildQuery(const std::vector<InstMapping> &PCs,
     PP->setForceNoLineBreaks(true);
     PP->scan(CE.E);
     PP->print(CE.E);
-    SMTSS << std::endl;
+    SMTSS << '\n';
   }
 
   return SMTSS.str();

--- a/unittests/Extractor/ExtractorTests.cpp
+++ b/unittests/Extractor/ExtractorTests.cpp
@@ -83,7 +83,8 @@ struct ExtractorTest : testing::Test {
 
   bool hasCandidateExpr(std::string Expected) {
     for (const auto &Cand : CandExprs) {
-      std::ostringstream SS;
+      std::string SStr;
+      llvm::raw_string_ostream SS(SStr);
 
       std::unique_ptr<ExprPPrinter> PP(ExprPPrinter::create(SS));
       PP->setForceNoLineBreaks(true);

--- a/update_deps.sh
+++ b/update_deps.sh
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-llvm_revision=217983
-klee_commit=5d8db05524f5216900e952c3e1fc2aac9c424391
-hiredis_commit=2602e1b6bc19dc191df0c50cd6502578fe492710
+llvm_revision=218733
+klee_commit=0c8c812db1d331f1e49e27ccd35f1288e58d97e6
+hiredis_commit=8f60ee65327445ed8384290b4040685329eb03c5
 
 llvm_build_type=Debug
 if [ -n "$1" ] ; then
@@ -61,4 +61,9 @@ else
   git clone https://github.com/redis/hiredis.git $hiredisdir
 fi
 
-(cd $hiredisdir && git checkout $hiredis_commit && PREFIX=install make install)
+mkdir -p $hiredisdir/install/include/hiredis
+mkdir -p $hiredisdir/install/lib
+
+(cd $hiredisdir && git checkout $hiredis_commit && make libhiredis.a &&
+ cp -r hiredis.h async.h adapters install/include/hiredis &&
+ cp libhiredis.a install/lib)

--- a/utils/sclang.in
+++ b/utils/sclang.in
@@ -67,7 +67,7 @@ if ($souper) {
     if ($ENV{"SOUPER_PROFILE"}) {
         push @ARGV, ("-g", "-mllvm", "-profile-souper-opts");
         if (linkp()) {
-            push @ARGV, ("@PROFILE_LIBRARY@", "@HIREDIS_STATIC_LIBRARY@");
+            push @ARGV, ("@PROFILE_LIBRARY@", "@HIREDIS_LIBRARY@");
         }
     }
 }


### PR DESCRIPTION
Note: although this change fixes the hiredis problem on my Mac, Souper on Mac still does not pass its tests. It tries to load libsouperPass.so instead of libsouperPass.dynlib. Let's fight that battle another day.
