### PR TITLE
A fix to address issue 26

### DIFF
--- a/test/Extractor/irreducible-cg.ll
+++ b/test/Extractor/irreducible-cg.ll
@@ -1,0 +1,60 @@
+
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+%class.A = type { i8 }
+
+@a = global i32 0, align 4
+
+; Function Attrs: nounwind uwtable
+define noalias i32* @foo(%class.A* nocapture readnone %this) #0 align 2 {
+entry:
+  %0 = load i32* @a, align 4, !tbaa !1
+  %tobool = icmp eq i32 %0, 0
+  br i1 %tobool, label %for.body, label %land.rhs
+
+land.rhs:                                         ; preds = %entry
+  %call = tail call i32 @bar() #2
+  br label %for.bodythread-pre-split
+
+for.bodythread-pre-split:                         ; preds = %for.inc, %land.rhs
+  %K.010.ph = phi i32 [ undef, %land.rhs ], [ %inc, %for.inc ]
+  %.pr = load i32* @a, align 4, !tbaa !1
+  %phitmp = icmp eq i32 %.pr, 0
+  br label %for.body
+
+for.body:                                         ; preds = %for.bodythread-pre-split, %entry
+  %1 = phi i1 [ %phitmp, %for.bodythread-pre-split ], [ true, %entry ]
+  %K.010 = phi i32 [ %K.010.ph, %for.bodythread-pre-split ], [ undef, %entry ]
+  br i1 %1, label %for.inc, label %land.rhs5
+
+land.rhs5:                                        ; preds = %for.body
+  %call6 = tail call i32 @bar() #2
+  br label %for.inc
+
+for.inc:                                          ; preds = %land.rhs5, %for.body
+  %inc = add nsw i32 %K.010, 1
+  %tobool3 = icmp eq i32 %inc, 0
+  br i1 %tobool3, label %for.end, label %for.bodythread-pre-split
+
+for.end:                                          ; preds = %for.inc
+  ret i32* null
+}
+
+declare i32 @bar() #1
+
+attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!llvm.ident = !{!0}
+
+!0 = metadata !{metadata !"clang version 3.5.0 (213048)"}
+!1 = metadata !{metadata !2, metadata !2, i64 0}
+!2 = metadata !{metadata !"int", metadata !3, i64 0}
+!3 = metadata !{metadata !"omnipotent char", metadata !4, i64 0}
+!4 = metadata !{metadata !"Simple C/C++ TBAA"}

--- a/test/Extractor/phi-1.ll
+++ b/test/Extractor/phi-1.ll
@@ -1,0 +1,32 @@
+
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+@a = common global i32* null, align 8
+
+; Function Attrs: nounwind uwtable
+define i32 @fn1() #0 {
+entry:
+  br i1 false, label %cond.end, label %cond.false
+
+cond.false:                                       ; preds = %entry
+  %0 = load i32** @a, align 8
+  %1 = load i32* %0, align 4
+  br label %cond.end
+
+cond.end:                                         ; preds = %entry, %cond.false
+  %cond = phi i32 [ %1, %cond.false ], [ undef, %entry ]
+  br label %for.cond
+
+for.cond:                                         ; preds = %for.cond, %cond.end
+  %tobool1 = icmp eq i32 %cond, 0
+  br i1 %tobool1, label %for.end, label %for.cond
+
+for.end:                                          ; preds = %for.cond
+  ret i32 undef
+}
+


### PR DESCRIPTION
The patch is to resolve issue 26, where Souper enters an infinite recursion when processing irreducible CFGs. The idea is that when we build an instruction, if the instruction is a phi-node with multiple incoming edges, we do DFS from the basic block containing the phi-node and check if we will revisit the basic block. If yes, we know that this phi-node is the merge point of loop iterations. All basic blocks along the path of the detected loop are cached for speeding up future queries. 
