### PR TITLE
cmd line help cleanup

### DIFF
--- a/include/souper/Tool/GetSolverFromArgs.h
+++ b/include/souper/Tool/GetSolverFromArgs.h
@@ -63,12 +63,12 @@ static std::unique_ptr<SMTLIBSolver> GetUnderlyingSolverFromArgs() {
 
 static llvm::cl::opt<bool> MemCache(
   "internal-cache-souper",
-  llvm::cl::desc("Cache solver results in memory (default=on)"),
+  llvm::cl::desc("Cache solver results in memory (default=true)"),
   llvm::cl::init(true));
 
 static llvm::cl::opt<bool> RedisCache(
   "external-cache-souper",
-  llvm::cl::desc("Use external Redis-based cache (default=off)"),
+  llvm::cl::desc("Use external Redis-based cache (default=false)"),
   llvm::cl::init(false));
 
 static llvm::cl::opt<int> SolverTimeout(


### PR DESCRIPTION
don't tell people the default is on/off since the cl::opt class doesn't accept those strings, use true/false instead
