### PR TITLE
Support for intrinsics cttz, ctlz, ctpop and bswap

### DIFF
--- a/include/souper/Inst/Inst.h
+++ b/include/souper/Inst/Inst.h
@@ -76,6 +76,10 @@ struct Inst : llvm::FoldingSetNode {
     Slt,
     Ule,
     Sle,
+    CtPop,
+    BSwap,
+    Cttz,
+    Ctlz,
   } Kind;
 
   Kind K;

--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -22,6 +22,8 @@
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
 #include "llvm/PassManager.h"
@@ -313,6 +315,22 @@ Inst *ExprBuilder::build(Value *V) {
         Incomings.push_back(get(Phi->getIncomingValueForBlock(Pred)));
       }
       return IC.getPhi(BI.B, Incomings);
+    }
+  } else if (auto Call = dyn_cast<CallInst>(V)) {
+    if (auto II = dyn_cast<IntrinsicInst>(Call)) {
+      Inst *L = get(II->getOperand(0));
+      switch (II->getIntrinsicID()) {
+        default:
+          break;
+        case Intrinsic::ctpop:
+          return IC.getInst(Inst::CtPop, 1, {L});
+        case Intrinsic::bswap:
+          return IC.getInst(Inst::BSwap, 1, {L});
+        case Intrinsic::cttz:
+          return IC.getInst(Inst::Cttz, 1, {L});
+        case Intrinsic::ctlz:
+          return IC.getInst(Inst::Ctlz, 1, {L});
+      }
     }
   }
 

--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -246,6 +246,14 @@ const char *Inst::getKindName(Kind K) {
     return "ule";
   case Sle:
     return "sle";
+  case CtPop:
+    return "ctpop";
+  case BSwap:
+    return "bswap";
+  case Cttz:
+    return "cttz";
+  case Ctlz:
+    return "ctlz";
   }
 
   llvm_unreachable("all cases covered");

--- a/test/Solver/bswap.ll
+++ b/test/Solver/bswap.ll
@@ -1,0 +1,19 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+; Function Attrs: nounwind readnone
+declare i16 @llvm.bswap.i16(i16) #0
+
+define i16 @foo(i16 %x) {
+entry:
+  %0 = shl i16 %x, 8
+  %1 = lshr i16 %x, 8
+  %2 = or i16 %0, %1
+  %swap1 = call i16 @llvm.bswap.i16(i16 %x)
+  %cmp1 = icmp eq i16 %swap1, %2, !expected !1
+  ret i16 %swap1
+}
+
+!1 = metadata !{ i1 1 }

--- a/test/Solver/bswap2.ll
+++ b/test/Solver/bswap2.ll
@@ -1,0 +1,19 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+; Function Attrs: nounwind readnone
+declare i32 @llvm.bswap.i32(i32) #0
+declare i32 @llvm.ctpop.i32(i32) #1
+
+define i32 @foo(i32 %x) {
+entry:
+  %count1 = call i32 @llvm.ctpop.i32(i32 %x)
+  %swap = call i32 @llvm.bswap.i32(i32 %x)
+  %count2 = call i32 @llvm.ctpop.i32(i32 %swap)
+  %cmp = icmp eq i32 %count1, %count2, !expected !1
+  ret i32 %swap
+}
+
+!1 = metadata !{ i1 1 }

--- a/test/Solver/bswap3.ll
+++ b/test/Solver/bswap3.ll
@@ -1,0 +1,16 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+; Function Attrs: nounwind readnone
+declare i32 @llvm.bswap.i32(i32) #0
+
+define i32 @foo(i32 %x) {
+entry:
+  %swap = call i32 @llvm.bswap.i32(i32 2882343476) ;input is 0xABCD1234
+  %cmp = icmp eq i32 %swap, 873647531, !expected !1 ;swapped result is 0x3412CDAB
+  ret i32 %swap
+}
+
+!1 = metadata !{ i1 1 }

--- a/test/Solver/bswap4.ll
+++ b/test/Solver/bswap4.ll
@@ -1,0 +1,16 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+; Function Attrs: nounwind readnone
+declare i64 @llvm.bswap.i64(i64) #0
+
+define i64 @foo(i64 %x) {
+entry:
+  %swap = call i64 @llvm.bswap.i64(i64 12379570966709668117) ;input is 0xABCD123456780915
+  %cmp = icmp eq i64 %swap, 1515875061223050667, !expected !1 ;swapped result is 0x150978563412CDAB
+  ret i64 %swap
+}
+
+!1 = metadata !{ i1 1 }

--- a/test/Solver/ctlz.ll
+++ b/test/Solver/ctlz.ll
@@ -1,0 +1,15 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+declare i64 @llvm.ctlz.i64(i64) nounwind readnone
+
+define i64 @foo(i64 %x) {
+entry:
+  %count = call i64 @llvm.ctlz.i64(i64 281479271743489) ;input is 0x0001000100010001
+  %cmp = icmp eq i64 %count, 15, !expected !1
+  ret i64 %count
+}
+
+!1 = metadata !{ i1 1 }

--- a/test/Solver/ctlz2.ll
+++ b/test/Solver/ctlz2.ll
@@ -1,0 +1,19 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+declare i32 @llvm.ctlz.i32(i32) nounwind readnone
+
+define i32 @foo(i32 %x) {
+entry:
+  %count = call i32 @llvm.ctlz.i32(i32 %x)
+  %shr = lshr i32 %x, 4
+  %count2 = call i32 @llvm.ctlz.i32(i32 %shr)
+  %diff = sub nuw i32 %count2, %count
+  %cmp = icmp ule i32 %diff, 4, !expected !1
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+!1 = metadata !{ i1 1 }

--- a/test/Solver/ctpop.ll
+++ b/test/Solver/ctpop.ll
@@ -1,0 +1,16 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+; This test case input in hex is 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+declare i256 @llvm.ctpop.i256(i256) nounwind readnone
+
+define i256 @foo(i256 %x) {
+entry:
+  %pop = call i256 @llvm.ctpop.i256(i256 77194726158210796949047323339125271902179989777093709359638389338608753093290)
+  %cmp = icmp eq i256 %pop, 128, !expected !1
+  ret i256 %pop
+}
+
+!1 = metadata !{ i1 1 }

--- a/test/Solver/ctpop2.ll
+++ b/test/Solver/ctpop2.ll
@@ -1,0 +1,22 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+declare i32 @llvm.ctpop.i32(i32) nounwind readnone
+
+define void @foo(i32 %x, i32 %y) {
+entry:
+  %pop1 = call i32 @llvm.ctpop.i32(i32 %x)
+  %notx = xor i32 %x, -1
+  %pop2 = call i32 @llvm.ctpop.i32(i32 %notx)
+  %sum = add i32 %pop1, %pop2
+  %cmp2 = icmp eq i32 %sum, 32, !expected !1
+  %shift = lshr exact i32 %x, %y
+  %pop3 = call i32 @llvm.ctpop.i32(i32 %shift)
+  %cmp3 = icmp eq i32 %pop1, %pop3, !expected !1
+  ret void
+
+}
+
+!1 = metadata !{ i1 1 }

--- a/test/Solver/cttz.ll
+++ b/test/Solver/cttz.ll
@@ -1,0 +1,16 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+declare i64 @llvm.cttz.i64(i64) nounwind readnone
+
+define i64 @foo(i64 %x) {
+entry:
+  %count = call i64 @llvm.cttz.i64(i64 9223372036854775808) ;input is 0x8000000000000000
+  %cmp = icmp eq i64 %count, 63, !expected !1
+  %conv = zext i1 %cmp to i64
+  ret i64 %conv
+}
+
+!1 = metadata !{ i1 1 }

--- a/test/Solver/cttz2.ll
+++ b/test/Solver/cttz2.ll
@@ -1,0 +1,21 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+declare i32 @llvm.cttz.i32(i32) nounwind readnone
+
+define void @foo(i32 %x, i32 %y) {
+entry:
+  %zero = icmp eq i32 %x, 0
+  %count1 = call i32 @llvm.cttz.i32(i32 %x)
+  %shift = shl nsw nuw i32 %x, %y
+  %count2 = call i32 @llvm.cttz.i32(i32 %shift)
+  %count1plusy = add i32 %count1, %y
+  %eq = icmp eq i32 %count1plusy, %count2
+  %cmp = or i1 %eq, %zero, !expected !1
+
+  ret void
+}
+
+!1 = metadata !{ i1 1 }

--- a/test/Solver/power2.ll
+++ b/test/Solver/power2.ll
@@ -1,0 +1,34 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+declare i64 @llvm.ctpop.i64(i64) nounwind readnone
+declare i64 @llvm.ctlz.i64(i64) nounwind readnone
+declare i64 @llvm.cttz.i64(i64) nounwind readnone
+
+define void @foo(i64 %x) {
+entry:
+  %isnotzero = icmp ne i64 %x, 0
+  %notx = xor i64 %x, -1
+  %notxp1 = add i64 %notx, 1
+  %and = and i64 %x, %notxp1
+  %eq = icmp eq i64 %and, %x
+  %power2 = and i1 %isnotzero, %eq
+  %pop = call i64 @llvm.ctpop.i64(i64 %x)
+  %lead = call i64 @llvm.ctlz.i64(i64 %x)
+  %trail = call i64 @llvm.cttz.i64(i64 %x)
+  %add = add i64 %lead, %trail
+  br i1 %power2, label %ispower2, label %notpower2
+ispower2:
+  %cmp1 = icmp eq i64 %pop, 1, !expected !1
+  %cmp2 = icmp eq i64 %add, 63, !expected !1
+  ret void
+notpower2:
+  %cmp3 = icmp eq i64 %pop, 1, !expected !0
+  %cmp4 = icmp eq i64 %add, 63, !expected !0
+  ret void
+}
+
+!0 = metadata !{ i1 0 }
+!1 = metadata !{ i1 1 }

--- a/test/Solver/zeros.ll
+++ b/test/Solver/zeros.ll
@@ -1,0 +1,53 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+declare i32 @llvm.ctlz.i32(i32) nounwind readnone
+declare i32 @llvm.cttz.i32(i32) nounwind readnone
+declare i32 @llvm.ctpop.i32(i32) nounwind readnone
+
+define void @foo(i32 %x) {
+entry:
+  %cmp0 = icmp eq i32 %x, 0
+  br i1 %cmp0, label %zero, label %nonzero
+
+zero:
+  %noones = call i32 @llvm.ctpop.i32(i32 %x)
+  %cmp1 = icmp eq i32 %noones, 0, !expected !1
+
+  %allZeros1 = call i32 @llvm.ctlz.i32(i32 %x)
+  %cmp2 = icmp eq i32 %allZeros1, 32, !expected !1
+
+  %allZeros2 = call i32 @llvm.cttz.i32(i32 %x)
+  %cmp3 = icmp eq i32 %allZeros2, 32, !expected !1
+
+  br label %out
+
+nonzero:
+  %ones = call i32 @llvm.ctpop.i32(i32 %x)
+  %cmp4 = icmp sgt i32 %ones, 0, !expected !1
+  %cmp5 = icmp sle i32 %ones, 32, !expected !1
+  %zeros = sub i32 32, %ones
+
+  %leadZeros = call i32 @llvm.ctlz.i32(i32 %x)
+  %cmp6 = icmp sge i32 %leadZeros, 0, !expected !1
+  %cmp7 = icmp slt i32 %leadZeros, 32, !expected !1
+
+  %trailZeros = call i32 @llvm.cttz.i32(i32 %x)
+  %cmp8 = icmp sge i32 %trailZeros, 0, !expected !1
+  %cmp9 = icmp slt i32 %trailZeros, 32, !expected !1
+
+  %ltZeros = add i32 %leadZeros, %trailZeros
+  %cmp10 = icmp sge i32 %ltZeros, 0, !expected !1
+  %cmp11 = icmp slt i32 %ltZeros, 32, !expected !1
+
+  %cmp12 = icmp slt i32 %zeros, %ltZeros, !expected !0
+  br label %out
+
+out:
+  ret void
+}
+
+!0 = metadata !{ i1 0 }
+!1 = metadata !{ i1 1 }

--- a/unittests/Parser/ParserTests.cpp
+++ b/unittests/Parser/ParserTests.cpp
@@ -51,6 +51,14 @@ TEST(ParserTest, Errors) {
       { "%0:i1 = phi %0\n", "<input>:1:13: %0 is not a block" },
       { "%0 = block\n%1:i1 = phi %0 foo\n", "<input>:2:16: expected ','" },
       { ",\n", "<input>:1:1: expected inst, block, cand, infer, result, or pc" },
+      { "%0:i128 = var ; 0\n%1:i128 = bswap %0\n",
+        "<input>:2:1: bswap doesn't support 128 bits" },
+      { "%0:i33 = var ; 0\n%1:i33 = ctpop %0\n",
+        "<input>:2:1: ctpop doesn't support 33 bits" },
+      { "%0:i70 = var ; 0\n%1:i70 = cttz %0\n",
+        "<input>:2:1: cttz doesn't support 70 bits" },
+      { "%0:i128 = var ; 0\n%1:i128 = ctlz %0\n",
+        "<input>:2:1: ctlz doesn't support 128 bits" },
 
       // type checking
       { "%0 = add 1:i32\n",
@@ -221,6 +229,26 @@ TEST(ParserTest, RoundTrip) {
 %8:i32 = ashr %7, 1:i32
 %9:i1 = eq 0:i32, %8
 cand %9 1:i1
+)i",
+      R"i(%0:i32 = var ; 0
+%1:i32 = ctpop %0
+%2:i1 = eq 1:i32, %1
+cand %2 1:i1
+)i",
+      R"i(%0:i32 = var ; 0
+%1:i32 = cttz %0
+%2:i1 = eq 1:i32, %1
+cand %2 1:i1
+)i",
+      R"i(%0:i32 = var ; 0
+%1:i32 = ctlz %0
+%2:i1 = eq 1:i32, %1
+cand %2 1:i1
+)i",
+      R"i(%0:i32 = var ; 0
+%1:i32 = bswap %0
+%2:i1 = eq 1:i32, %1
+cand %2 1:i1
 )i",
   };
 


### PR DESCRIPTION
This patch adds support for all intrinsics with corresponding test cases.
