### PR TITLE
first cut at Redis refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,15 @@ add_library(souperExtractor STATIC
   ${SOUPER_EXTRACTOR_FILES}
 )
 
+set(SOUPER_KVSTORE_FILES
+  lib/KVStore/KVStore.cpp
+  include/souper/KVStore/KVStore.h
+)
+
+add_library(souperKVStore STATIC
+  ${SOUPER_KVSTORE_FILES}
+)
+
 set(SOUPER_INST_FILES
   lib/Inst/Inst.cpp
   include/souper/Inst/Inst.h
@@ -166,6 +175,7 @@ add_library(souperPass SHARED
   ${KLEE_EXPR_FILES}
   ${SOUPER_EXTRACTOR_FILES}
   ${SOUPER_INST_FILES}
+  ${SOUPER_KVSTORE_FILES}
   ${SOUPER_PARSER_FILES}
   ${SOUPER_SMTLIB2_FILES}
   ${SOUPER_TOOL_FILES}
@@ -208,7 +218,7 @@ add_executable(parser_tests
   unittests/Parser/ParserTests.cpp
 )
 
-set_target_properties(souper internal-solver-test lexer-test parser-test souper-check souperExtractor souperInst souperParser souperSMTLIB2 souperTool souperPass kleeExpr
+set_target_properties(souper internal-solver-test lexer-test parser-test souper-check souperExtractor souperInst souperKVStore souperParser souperSMTLIB2 souperTool souperPass kleeExpr
   PROPERTIES COMPILE_FLAGS "${LLVM_CXXFLAGS}")
 set_target_properties(souperClangTool clang-souper
   PROPERTIES COMPILE_FLAGS "${CLANG_CXXFLAGS} ${LLVM_CXXFLAGS}")
@@ -219,16 +229,17 @@ target_link_libraries(kleeExpr ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperClangTool souperExtractor souperTool ${CLANG_LIBS} ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperExtractor souperInst kleeExpr)
 target_link_libraries(souperInst ${LLVM_LIBS} ${LLVM_LDFLAGS})
+target_link_libraries(souperKVStore ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperParser souperInst ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperSMTLIB2 ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperTool souperExtractor souperSMTLIB2)
 target_link_libraries(souperPass ${PASS_LDFLAGS} ${HIREDIS_LIBRARY})
-target_link_libraries(souper souperExtractor souperParser souperSMTLIB2 souperTool kleeExpr ${HIREDIS_LIBRARY})
+target_link_libraries(souper souperExtractor souperKVStore souperParser souperSMTLIB2 souperTool kleeExpr ${HIREDIS_LIBRARY})
 target_link_libraries(internal-solver-test souperSMTLIB2)
 target_link_libraries(lexer-test souperParser)
 target_link_libraries(parser-test souperParser)
-target_link_libraries(souper-check souperTool souperExtractor souperSMTLIB2 souperParser souperInst ${HIREDIS_LIBRARY})
-target_link_libraries(clang-souper souperClangTool souperExtractor souperParser souperSMTLIB2 souperTool kleeExpr ${CLANG_LIBS} ${LLVM_LIBS} ${LLVM_LDFLAGS} ${HIREDIS_LIBRARY})
+target_link_libraries(souper-check souperTool souperExtractor souperKVStore souperSMTLIB2 souperParser souperInst ${HIREDIS_LIBRARY})
+target_link_libraries(clang-souper souperClangTool souperExtractor souperKVStore souperParser souperSMTLIB2 souperTool kleeExpr ${CLANG_LIBS} ${LLVM_LIBS} ${LLVM_LDFLAGS} ${HIREDIS_LIBRARY})
 target_link_libraries(extractor_tests souperExtractor ${GTEST_LIBS})
 target_link_libraries(inst_tests souperInst ${GTEST_LIBS})
 target_link_libraries(parser_tests souperParser ${GTEST_LIBS})

--- a/include/souper/Extractor/Solver.h
+++ b/include/souper/Extractor/Solver.h
@@ -30,7 +30,7 @@ public:
   virtual ~Solver();
   virtual std::error_code
   infer(const std::vector<InstMapping> &PCs, Inst *LHS, Inst *&RHS,
-        const InstOrigin *O, InstContext &IC) = 0;
+        InstContext &IC) = 0;
   virtual std::error_code
   isValid(const std::vector<InstMapping> &PCs, InstMapping Mapping,
           bool &IsValid,
@@ -42,7 +42,7 @@ std::unique_ptr<Solver> createBaseSolver(
     std::unique_ptr<SMTLIBSolver> SMTSolver, unsigned Timeout);
 std::unique_ptr<Solver> createMemCachingSolver(
     std::unique_ptr<Solver> UnderlyingSolver);
-std::unique_ptr<Solver> createRedisCachingSolver(
+std::unique_ptr<Solver> createExternalCachingSolver(
     std::unique_ptr<Solver> UnderlyingSolver);
 
 }

--- a/include/souper/KVStore/KVStore.h
+++ b/include/souper/KVStore/KVStore.h
@@ -1,0 +1,38 @@
+// Copyright 2014 The Souper Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOUPER_KVSTORE_KVSTORE_H
+#define SOUPER_KVSTORE_KVSTORE_H
+
+#include "llvm/ADT/StringRef.h"
+#include <memory>
+
+namespace souper {
+
+class KVStore {
+  class KVImpl;
+  std::unique_ptr<KVImpl> Impl;
+public:
+  KVStore();
+  ~KVStore();
+  void hIncrBy(llvm::StringRef Key, llvm::StringRef Field, int Incr);
+  bool hGet(llvm::StringRef Key, llvm::StringRef Field, std::string &Value);
+  void hSet(llvm::StringRef Key, llvm::StringRef Field, llvm::StringRef Value);
+};
+
+extern KVStore *KV;
+
+}
+
+#endif  // SOUPER_KVSTORE_KVSTORE_H

--- a/include/souper/Tool/CandidateMapUtils.h
+++ b/include/souper/Tool/CandidateMapUtils.h
@@ -38,7 +38,7 @@ void AddModuleToCandidateMap(InstContext &IC, ExprBuilderContext &EBC,
                              CandidateMap &CandMap, llvm::Module *M);
 
 bool SolveCandidateMap(llvm::raw_ostream &OS, CandidateMap &M,
-                       Solver *Solver, InstContext &IC);
+                       Solver *Solver, InstContext &IC, bool StaticProfile);
 
 bool CheckCandidateMap(llvm::Module &Mod, CandidateMap &M, Solver *S,
                        InstContext &IC);

--- a/include/souper/Tool/GetSolverFromArgs.h
+++ b/include/souper/Tool/GetSolverFromArgs.h
@@ -66,7 +66,7 @@ static llvm::cl::opt<bool> MemCache(
   llvm::cl::desc("Cache solver results in memory (default=true)"),
   llvm::cl::init(true));
 
-static llvm::cl::opt<bool> RedisCache(
+static llvm::cl::opt<bool> ExternalCache(
   "souper-external-cache",
   llvm::cl::desc("Use external Redis-based cache (default=false)"),
   llvm::cl::init(false));
@@ -80,8 +80,8 @@ static std::unique_ptr<Solver> GetSolverFromArgs() {
   std::unique_ptr<SMTLIBSolver> US = GetUnderlyingSolverFromArgs();
   if (!US) return NULL;
   std::unique_ptr<Solver> S = createBaseSolver (std::move(US), SolverTimeout);
-  if (RedisCache) {
-    S = createRedisCachingSolver (std::move(S));
+  if (ExternalCache) {
+    S = createExternalCachingSolver (std::move(S));
   }
   if (MemCache) {
     S = createMemCachingSolver (std::move(S));

--- a/lib/Extractor/Solver.cpp
+++ b/lib/Extractor/Solver.cpp
@@ -17,12 +17,11 @@
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/Instruction.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "souper/Extractor/Solver.h"
+#include "souper/KVStore/KVStore.h"
 #include "souper/Parser/Parser.h"
 
-#include "hiredis.h"
 #include <sstream>
 #include <unordered_map>
 
@@ -30,17 +29,14 @@ STATISTIC(MemHitsInfer, "Number of internal cache hits for infer()");
 STATISTIC(MemMissesInfer, "Number of internal cache misses for infer()");
 STATISTIC(MemHitsIsValid, "Number of internal cache hits for isValid()");
 STATISTIC(MemMissesIsValid, "Number of internal cache misses for isValid()");
-STATISTIC(RedisHits, "Number of external cache hits");
-STATISTIC(RedisMisses, "Number of external cache misses");
+STATISTIC(ExternalHits, "Number of external cache hits");
+STATISTIC(ExternalMisses, "Number of external cache misses");
 STATISTIC(TriviallyInvalid, "Number of trivially invalid expressions");
 
 using namespace souper;
 using namespace llvm;
 
 namespace {
-
-static cl::opt<bool> StaticProfile("souper-static-profile", cl::init(true),
-    cl::desc("Static profiling of Souper optimizations (default=true)"));
 
 class BaseSolver : public Solver {
   std::unique_ptr<SMTLIBSolver> SMTSolver;
@@ -51,8 +47,7 @@ public:
       : SMTSolver(std::move(SMTSolver)), Timeout(Timeout) {}
 
   std::error_code infer(const std::vector<InstMapping> &PCs,
-                        Inst *LHS, Inst *&RHS, const InstOrigin *O,
-                        InstContext &IC) {
+                        Inst *LHS, Inst *&RHS, InstContext &IC) {
     assert(LHS->Width == 1);
     std::error_code EC;
     std::vector<Inst *>Guesses { IC.getConst(APInt(1, true)),
@@ -125,13 +120,12 @@ public:
       : UnderlyingSolver(std::move(UnderlyingSolver)) {}
 
   std::error_code infer(const std::vector<InstMapping> &PCs,
-                        Inst *LHS, Inst *&RHS, const InstOrigin *O,
-                        InstContext &IC) {
+                        Inst *LHS, Inst *&RHS, InstContext &IC) {
     std::string Repl = GetReplacementLHSString(PCs, LHS);
     const auto &ent = InferCache.find(Repl);
     if (ent == InferCache.end()) {
       ++MemMissesInfer;
-      std::error_code EC = UnderlyingSolver->infer(PCs, LHS, RHS, O, IC);
+      std::error_code EC = UnderlyingSolver->infer(PCs, LHS, RHS, IC);
       std::string RHSStr;
       if (!EC && RHS) {
         assert(RHS->K == Inst::Const);
@@ -182,99 +176,42 @@ public:
 
 };
 
-class RedisCachingSolver : public Solver {
+class ExternalCachingSolver : public Solver {
   std::unique_ptr<Solver> UnderlyingSolver;
-  redisContext *ctx;
 
 public:
-  RedisCachingSolver(std::unique_ptr<Solver> UnderlyingSolver)
+  ExternalCachingSolver(std::unique_ptr<Solver> UnderlyingSolver)
       : UnderlyingSolver(std::move(UnderlyingSolver)) {
-
-    // get these from cmd line?
-    const char *hostname = "127.0.0.1";
-    int port = 6379;
-
-    struct timeval timeout = { 1, 500000 }; // 1.5 seconds
-    ctx = redisConnectWithTimeout(hostname, port, timeout);
-    if (!ctx) {
-      llvm::report_fatal_error("Can't allocate redis context\n");
-    }
-    if (ctx->err) {
-      llvm::report_fatal_error((std::string)"Redis connection error: " +
-                               ctx->errstr + "\n");
-    }
+    if (!KV)
+      KV = new KVStore;
   }
 
   std::error_code infer(const std::vector<InstMapping> &PCs,
-                        Inst *LHS, Inst *&RHS, const InstOrigin *O,
-                        InstContext &IC) {
+                        Inst *LHS, Inst *&RHS, InstContext &IC) {
     std::string LHSStr = GetReplacementLHSString(PCs, LHS);
-
-    if (StaticProfile) {
-      std::string Str;
-      llvm::raw_string_ostream Loc(Str);
-      if (O) {
-        Instruction *I = O->getInstruction();
-        I->getDebugLoc().print(I->getContext(), Loc);
-      }
-      std::string HField = "sprofile " + Loc.str();
-      redisReply *reply = (redisReply *)redisCommand(ctx, "HINCRBY %s %s 1",
-          LHSStr.c_str(), HField.c_str());
-      if (!reply || ctx->err) {
-        llvm::report_fatal_error((std::string)"Redis error: " + ctx->errstr);
-      }
-      if (reply->type != REDIS_REPLY_INTEGER) {
-        llvm::report_fatal_error(
-            "Redis protocol error for static profile, didn't expect reply type "
-            + std::to_string(reply->type));
-      }
-      freeReplyObject(reply);
-    }
-
-    redisReply *reply = (redisReply *)redisCommand(ctx, "HGET %s result",
-                                                   LHSStr.c_str());
-    if (!reply || ctx->err) {
-      llvm::report_fatal_error((std::string)"Redis error: " + ctx->errstr);
-    }
-    if (reply->type == REDIS_REPLY_NIL) {
-      freeReplyObject(reply);
-      ++RedisMisses;
-      std::error_code EC = UnderlyingSolver->infer(PCs, LHS, RHS, O, IC);
-      std::string RHSStr;
-      if (!EC && RHS) {
-        assert(RHS->K == Inst::Const);
-        RHSStr = GetReplacementRHSString(RHS->Val);
-      }
-      reply = (redisReply *)redisCommand(ctx, "HSET %s result %s",
-                                         LHSStr.c_str(), RHSStr.c_str());
-      if (!reply || ctx->err) {
-        llvm::report_fatal_error((std::string)"Redis error: " + ctx->errstr);
-      }
-      if (reply->type != REDIS_REPLY_INTEGER) {
-        llvm::report_fatal_error(
-            "Redis protocol error for cache fill, didn't expect reply type " +
-            std::to_string(reply->type));
-      }
-      freeReplyObject(reply);
-      return EC;
-    } else if (reply->type == REDIS_REPLY_STRING) {
-      ++RedisHits;
-      std::string ES;
-      StringRef S = reply->str;
+    std::string S;
+    if (KV->hGet(LHSStr, "result", S)) {
+      ++ExternalHits;
       if (S == "") {
         RHS = 0;
       } else {
+        std::string ES;
         ParsedReplacement R = ParseReplacementRHS(IC, "<cache>", S, ES);
         if (ES != "")
           return std::make_error_code(std::errc::protocol_error);
         RHS = R.Mapping.RHS;
       }
-      freeReplyObject(reply);
       return std::error_code();
     } else {
-      llvm::report_fatal_error(
-          "Redis protocol error for cache lookup, didn't expect reply type " +
-          std::to_string(reply->type));
+      ++ExternalMisses;
+      std::error_code EC = UnderlyingSolver->infer(PCs, LHS, RHS, IC);
+      std::string RHSStr;
+      if (!EC && RHS) {
+        assert(RHS->K == Inst::Const);
+        RHSStr = GetReplacementRHSString(RHS->Val);
+      }
+      KV->hSet(LHSStr, "result", RHSStr);
+      return EC;
     }
   }
 
@@ -282,7 +219,7 @@ public:
                           InstMapping Mapping, bool &IsValid,
                           std::vector<std::pair<Inst *, llvm::APInt>> *Model) {
     // N.B. we decided that since the important clients have moved to infer(),
-    // we'll no longer support Redis-based caching for isValid()
+    // we'll no longer support external caching for isValid()
     return UnderlyingSolver->isValid(PCs, Mapping, IsValid, Model);
   }
 
@@ -309,10 +246,10 @@ std::unique_ptr<Solver> createMemCachingSolver(
       new MemCachingSolver(std::move(UnderlyingSolver)));
 }
 
-std::unique_ptr<Solver> createRedisCachingSolver(
+std::unique_ptr<Solver> createExternalCachingSolver(
     std::unique_ptr<Solver> UnderlyingSolver) {
   return std::unique_ptr<Solver>(
-      new RedisCachingSolver(std::move(UnderlyingSolver)));
+      new ExternalCachingSolver(std::move(UnderlyingSolver)));
 }
 
 }

--- a/lib/KVStore/KVStore.cpp
+++ b/lib/KVStore/KVStore.cpp
@@ -1,0 +1,126 @@
+// Copyright 2014 The Souper Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "souper/KVStore/KVStore.h"
+
+#include "llvm/Support/CommandLine.h"
+#include "hiredis.h"
+
+using namespace llvm;
+using namespace souper;
+
+static cl::opt<unsigned> RedisPort("souper-redis-port", cl::init(6379),
+    cl::desc("Redis server port (default=6379)"));
+
+namespace souper {
+
+class KVStore::KVImpl {
+  redisContext *Ctx;
+public:
+  KVImpl();
+  ~KVImpl();
+  void hIncrBy(llvm::StringRef Key, llvm::StringRef Field, int Incr);
+  bool hGet(llvm::StringRef Key, llvm::StringRef Field, std::string &Value);
+  void hSet(llvm::StringRef Key, llvm::StringRef Field, llvm::StringRef Value);
+};
+
+KVStore::KVImpl::KVImpl() {
+  const char *hostname = "127.0.0.1";
+  struct timeval Timeout = { 1, 500000 }; // 1.5 seconds
+  Ctx = redisConnectWithTimeout(hostname, RedisPort, Timeout);
+  if (!Ctx) {
+    llvm::report_fatal_error("Can't allocate redis context\n");
+  }
+  if (Ctx->err) {
+    llvm::report_fatal_error((llvm::StringRef)"Redis connection error: " +
+                             Ctx->errstr + "\n");
+  }
+}
+
+KVStore::KVImpl::~KVImpl() {
+  redisFree(Ctx);
+}
+
+void KVStore::KVImpl::hIncrBy(llvm::StringRef Key, llvm::StringRef Field,
+                              int Incr) {
+  redisReply *reply = (redisReply *)redisCommand(Ctx, "HINCRBY %s %s 1",
+                                                 Key.data(), Field.data());
+  if (!reply || Ctx->err) {
+    llvm::report_fatal_error((llvm::StringRef)"Redis error: " + Ctx->errstr);
+  }
+  if (reply->type != REDIS_REPLY_INTEGER) {
+    llvm::report_fatal_error(
+        "Redis protocol error for static profile, didn't expect reply type "
+        + std::to_string(reply->type));
+  }
+  freeReplyObject(reply);
+}
+
+bool KVStore::KVImpl::hGet(llvm::StringRef Key, llvm::StringRef Field,
+                           std::string &Value) {
+  redisReply *reply = (redisReply *)redisCommand(Ctx, "HGET %s %s", Key.data(),
+                                                 Field.data());
+  if (!reply || Ctx->err) {
+    llvm::report_fatal_error((llvm::StringRef)"Redis error: " + Ctx->errstr);
+  }
+  if (reply->type == REDIS_REPLY_NIL) {
+    freeReplyObject(reply);
+    return false;
+  } else if (reply->type == REDIS_REPLY_STRING) {
+    Value = reply->str;
+    freeReplyObject(reply);
+    return true;
+  } else {
+    llvm::report_fatal_error(
+        "Redis protocol error for cache lookup, didn't expect reply type " +
+        std::to_string(reply->type));
+  }
+}
+
+void KVStore::KVImpl::hSet(llvm::StringRef Key, llvm::StringRef Field,
+                              llvm::StringRef Value) {
+  redisReply *reply = (redisReply *)redisCommand(Ctx, "HSET %s %s %s",
+      Key.data(), Field.data(), Value.data());
+  if (!reply || Ctx->err) {
+    llvm::report_fatal_error((llvm::StringRef)"Redis error: " + Ctx->errstr);
+  }
+  if (reply->type != REDIS_REPLY_INTEGER) {
+    llvm::report_fatal_error(
+        "Redis protocol error for cache fill, didn't expect reply type " +
+        std::to_string(reply->type));
+  }
+  freeReplyObject(reply);
+}
+
+KVStore::KVStore() : Impl (new KVImpl) {}
+
+KVStore::~KVStore() {}
+
+void KVStore::hIncrBy(llvm::StringRef Key, llvm::StringRef Field, int Incr) {
+  Impl->hIncrBy(Key, Field, Incr);
+}
+
+bool KVStore::hGet(llvm::StringRef Key, llvm::StringRef Field,
+                   std::string &Value) {
+  return Impl->hGet(Key, Field, Value);
+}
+
+void KVStore::hSet(llvm::StringRef Key, llvm::StringRef Field,
+                   llvm::StringRef Value) {
+  Impl->hSet(Key, Field, Value);
+}
+
+KVStore *KV;
+
+}

--- a/test/Pass/clang-pass-profile.c
+++ b/test/Pass/clang-pass-profile.c
@@ -1,6 +1,6 @@
 // REQUIRES: solver
 
-// RUN: env SOUPER_NO_EXTERNAL_CACHE=1 SOUPER_PROFILE=1 SOUPER_SOLVER=%solver %sclang -O %s -o %t
+// RUN: env SOUPER_NO_EXTERNAL_CACHE=1 SOUPER_DYNAMIC_PROFILE=1 SOUPER_SOLVER=%solver %sclang -O %s -o %t
 
 // RUN: env SOUPER_PROFILE_TO_STDOUT=1 %t 0 | FileCheck %s -check-prefix=ARG0
 // ARG0: count = 0

--- a/tools/clang-souper.cpp
+++ b/tools/clang-souper.cpp
@@ -51,5 +51,5 @@ int main(int argc, const char **argv) {
   Tool.run(Factory.get());
 
   std::unique_ptr<Solver> S = GetSolverFromArgs();
-  return SolveCandidateMap(llvm::outs(), CandMap, S.get(), IC) ? 0 : 1;
+  return SolveCandidateMap(llvm::outs(), CandMap, S.get(), IC, false) ? 0 : 1;
 }

--- a/tools/souper-check.cpp
+++ b/tools/souper-check.cpp
@@ -52,7 +52,7 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
 
   if (InferRHS) {
     if (std::error_code EC = S->infer(Rep.PCs, Rep.Mapping.LHS, Rep.Mapping.RHS,
-                                      0, IC)) {
+                                      IC)) {
       llvm::errs() << EC.message() << '\n';
       return 1;
     }

--- a/tools/souper.cpp
+++ b/tools/souper.cpp
@@ -44,6 +44,9 @@ static cl::opt<std::string>
 OutputFilename("o", cl::desc("Override output filename"),
     cl::init(""), cl::value_desc("filename"));
 
+static cl::opt<bool> StaticProfile("souper-static-profile", cl::init(false),
+    cl::desc("Static profiling of Souper optimizations (default=false)"));
+
 static cl::opt<bool>
 Check("check", cl::desc("Check input for expected results"),
     cl::init(false));
@@ -101,6 +104,7 @@ int main(int argc, char **argv) {
   if (Check) {
     return CheckCandidateMap(*M.get(), CandMap, S.get(), IC) ? 0 : 1;
   } else {
-    return SolveCandidateMap(llvm::outs(), CandMap, S.get(), IC) ? 0 : 1;
+    return SolveCandidateMap(llvm::outs(), CandMap, S.get(), IC, StaticProfile)
+      ? 0 : 1;
   }
 }

--- a/utils/sclang.in
+++ b/utils/sclang.in
@@ -68,8 +68,12 @@ if ($souper) {
         push @ARGV, ("-mllvm", "-stats");
     }
 
-    if ($ENV{"SOUPER_PROFILE"}) {
-        push @ARGV, ("-g", "-mllvm", "-souper-profile-opts");
+    if ($ENV{"SOUPER_STATIC_PROFILE"}) {
+        push @ARGV, ("-mllvm", "-souper-static-profile");
+    }
+
+    if ($ENV{"SOUPER_DYNAMIC_PROFILE"}) {
+        push @ARGV, ("-g", "-mllvm", "-souper-dynamic-profile");
         if (linkp()) {
             push @ARGV, ("@PROFILE_LIBRARY@", "@HIREDIS_LIBRARY@");
         }


### PR DESCRIPTION
I wasn't certain how to best hide redis inside KVStore.cpp and opted for an opaque subclass, is that reasonable?

the other thing I did that may not have been a good idea was to make a global variable for the KVStore. it did not seem worth it to force clients to create this pointer and then thread it through a bunch of calls. but perhaps that's the right design? or perhaps there's a different way that I'm overlooking.

otherwise, I think this is fairly solid. the souper and souperPass clients both support static profiling. profile counts for not-optimizations are inflated by 5x and I am OK with that since optimizations and not-optimizations are incomparable things. the only thing that matters is the relative profile weight of optimizations and of not-optimizations, and those are treated correctly by this implementation.
