### PR TITLE
redis refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,15 @@ add_library(souperExtractor STATIC
   ${SOUPER_EXTRACTOR_FILES}
 )
 
+set(SOUPER_KVSTORE_FILES
+  lib/KVStore/KVStore.cpp
+  include/souper/KVStore/KVStore.h
+)
+
+add_library(souperKVStore STATIC
+  ${SOUPER_KVSTORE_FILES}
+)
+
 set(SOUPER_INST_FILES
   lib/Inst/Inst.cpp
   include/souper/Inst/Inst.h
@@ -166,6 +175,7 @@ add_library(souperPass SHARED
   ${KLEE_EXPR_FILES}
   ${SOUPER_EXTRACTOR_FILES}
   ${SOUPER_INST_FILES}
+  ${SOUPER_KVSTORE_FILES}
   ${SOUPER_PARSER_FILES}
   ${SOUPER_SMTLIB2_FILES}
   ${SOUPER_TOOL_FILES}
@@ -208,7 +218,7 @@ add_executable(parser_tests
   unittests/Parser/ParserTests.cpp
 )
 
-set_target_properties(souper internal-solver-test lexer-test parser-test souper-check souperExtractor souperInst souperParser souperSMTLIB2 souperTool souperPass kleeExpr
+set_target_properties(souper internal-solver-test lexer-test parser-test souper-check souperExtractor souperInst souperKVStore souperParser souperSMTLIB2 souperTool souperPass kleeExpr
   PROPERTIES COMPILE_FLAGS "${LLVM_CXXFLAGS}")
 set_target_properties(souperClangTool clang-souper
   PROPERTIES COMPILE_FLAGS "${CLANG_CXXFLAGS} ${LLVM_CXXFLAGS}")
@@ -219,16 +229,17 @@ target_link_libraries(kleeExpr ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperClangTool souperExtractor souperTool ${CLANG_LIBS} ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperExtractor souperInst kleeExpr)
 target_link_libraries(souperInst ${LLVM_LIBS} ${LLVM_LDFLAGS})
+target_link_libraries(souperKVStore ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperParser souperInst ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperSMTLIB2 ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperTool souperExtractor souperSMTLIB2)
 target_link_libraries(souperPass ${PASS_LDFLAGS} ${HIREDIS_LIBRARY})
-target_link_libraries(souper souperExtractor souperParser souperSMTLIB2 souperTool kleeExpr ${HIREDIS_LIBRARY})
+target_link_libraries(souper souperExtractor souperKVStore souperParser souperSMTLIB2 souperTool kleeExpr ${HIREDIS_LIBRARY})
 target_link_libraries(internal-solver-test souperSMTLIB2)
 target_link_libraries(lexer-test souperParser)
 target_link_libraries(parser-test souperParser)
-target_link_libraries(souper-check souperTool souperExtractor souperSMTLIB2 souperParser souperInst ${HIREDIS_LIBRARY})
-target_link_libraries(clang-souper souperClangTool souperExtractor souperParser souperSMTLIB2 souperTool kleeExpr ${CLANG_LIBS} ${LLVM_LIBS} ${LLVM_LDFLAGS} ${HIREDIS_LIBRARY})
+target_link_libraries(souper-check souperTool souperExtractor souperKVStore souperSMTLIB2 souperParser souperInst ${HIREDIS_LIBRARY})
+target_link_libraries(clang-souper souperClangTool souperExtractor souperKVStore souperParser souperSMTLIB2 souperTool kleeExpr ${CLANG_LIBS} ${LLVM_LIBS} ${LLVM_LDFLAGS} ${HIREDIS_LIBRARY})
 target_link_libraries(extractor_tests souperExtractor ${GTEST_LIBS})
 target_link_libraries(inst_tests souperInst ${GTEST_LIBS})
 target_link_libraries(parser_tests souperParser ${GTEST_LIBS})
@@ -252,7 +263,7 @@ if(NOT GO_EXECUTABLE STREQUAL "GO_EXECUTABLE-NOTFOUND")
   set_target_properties(souperweb-backend
     PROPERTIES COMPILE_FLAGS "${LLVM_CXXFLAGS}")
 
-  target_link_libraries(souperweb-backend souperTool souperExtractor souperSMTLIB2 souperParser souperInst ${HIREDIS_LIBRARY})
+  target_link_libraries(souperweb-backend souperTool souperExtractor souperKVStore souperSMTLIB2 souperParser souperInst ${HIREDIS_LIBRARY})
 
   add_custom_target(souperweb ALL COMMAND ${GO_EXECUTABLE} build -o ${CMAKE_BINARY_DIR}/souperweb ${CMAKE_SOURCE_DIR}/tools/souperweb.go
                                   COMMENT "Building souperweb")

--- a/include/souper/Extractor/Solver.h
+++ b/include/souper/Extractor/Solver.h
@@ -16,6 +16,7 @@
 #define SOUPER_EXTRACTOR_SOLVER_H
 
 #include "llvm/ADT/APInt.h"
+#include "souper/KVStore/KVStore.h"
 #include "souper/Tool/CandidateMapUtils.h"
 #include "souper/Extractor/Candidates.h"
 #include "souper/SMTLIB2/Solver.h"
@@ -30,7 +31,7 @@ public:
   virtual ~Solver();
   virtual std::error_code
   infer(const std::vector<InstMapping> &PCs, Inst *LHS, Inst *&RHS,
-        const InstOrigin *O, InstContext &IC) = 0;
+        InstContext &IC) = 0;
   virtual std::error_code
   isValid(const std::vector<InstMapping> &PCs, InstMapping Mapping,
           bool &IsValid,
@@ -42,8 +43,8 @@ std::unique_ptr<Solver> createBaseSolver(
     std::unique_ptr<SMTLIBSolver> SMTSolver, unsigned Timeout);
 std::unique_ptr<Solver> createMemCachingSolver(
     std::unique_ptr<Solver> UnderlyingSolver);
-std::unique_ptr<Solver> createRedisCachingSolver(
-    std::unique_ptr<Solver> UnderlyingSolver);
+std::unique_ptr<Solver> createExternalCachingSolver(
+    std::unique_ptr<Solver> UnderlyingSolver, KVStore *KV);
 
 }
 

--- a/include/souper/KVStore/KVStore.h
+++ b/include/souper/KVStore/KVStore.h
@@ -1,0 +1,36 @@
+// Copyright 2014 The Souper Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOUPER_KVSTORE_KVSTORE_H
+#define SOUPER_KVSTORE_KVSTORE_H
+
+#include "llvm/ADT/StringRef.h"
+#include <memory>
+
+namespace souper {
+
+class KVStore {
+  class KVImpl;
+  std::unique_ptr<KVImpl> Impl;
+public:
+  KVStore();
+  ~KVStore();
+  void hIncrBy(llvm::StringRef Key, llvm::StringRef Field, int Incr);
+  bool hGet(llvm::StringRef Key, llvm::StringRef Field, std::string &Value);
+  void hSet(llvm::StringRef Key, llvm::StringRef Field, llvm::StringRef Value);
+};
+
+}
+
+#endif  // SOUPER_KVSTORE_KVSTORE_H

--- a/include/souper/Tool/CandidateMapUtils.h
+++ b/include/souper/Tool/CandidateMapUtils.h
@@ -19,6 +19,7 @@
 #include "souper/Extractor/Candidates.h"
 #include "souper/Extractor/KLEEBuilder.h"
 #include "souper/Extractor/Solver.h"
+#include "souper/KVStore/KVStore.h"
 
 namespace llvm {
 
@@ -38,7 +39,8 @@ void AddModuleToCandidateMap(InstContext &IC, ExprBuilderContext &EBC,
                              CandidateMap &CandMap, llvm::Module *M);
 
 bool SolveCandidateMap(llvm::raw_ostream &OS, CandidateMap &M,
-                       Solver *Solver, InstContext &IC);
+                       Solver *Solver, InstContext &IC, bool StaticProfile,
+                       KVStore *KV);
 
 bool CheckCandidateMap(llvm::Module &Mod, CandidateMap &M, Solver *S,
                        InstContext &IC);

--- a/lib/Extractor/Solver.cpp
+++ b/lib/Extractor/Solver.cpp
@@ -17,12 +17,11 @@
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/Instruction.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "souper/Extractor/Solver.h"
+#include "souper/KVStore/KVStore.h"
 #include "souper/Parser/Parser.h"
 
-#include "hiredis.h"
 #include <sstream>
 #include <unordered_map>
 
@@ -30,17 +29,14 @@ STATISTIC(MemHitsInfer, "Number of internal cache hits for infer()");
 STATISTIC(MemMissesInfer, "Number of internal cache misses for infer()");
 STATISTIC(MemHitsIsValid, "Number of internal cache hits for isValid()");
 STATISTIC(MemMissesIsValid, "Number of internal cache misses for isValid()");
-STATISTIC(RedisHits, "Number of external cache hits");
-STATISTIC(RedisMisses, "Number of external cache misses");
+STATISTIC(ExternalHits, "Number of external cache hits");
+STATISTIC(ExternalMisses, "Number of external cache misses");
 STATISTIC(TriviallyInvalid, "Number of trivially invalid expressions");
 
 using namespace souper;
 using namespace llvm;
 
 namespace {
-
-static cl::opt<bool> StaticProfile("souper-static-profile", cl::init(true),
-    cl::desc("Static profiling of Souper optimizations (default=true)"));
 
 class BaseSolver : public Solver {
   std::unique_ptr<SMTLIBSolver> SMTSolver;
@@ -51,8 +47,7 @@ public:
       : SMTSolver(std::move(SMTSolver)), Timeout(Timeout) {}
 
   std::error_code infer(const std::vector<InstMapping> &PCs,
-                        Inst *LHS, Inst *&RHS, const InstOrigin *O,
-                        InstContext &IC) {
+                        Inst *LHS, Inst *&RHS, InstContext &IC) {
     assert(LHS->Width == 1);
     std::error_code EC;
     std::vector<Inst *>Guesses { IC.getConst(APInt(1, true)),
@@ -125,13 +120,12 @@ public:
       : UnderlyingSolver(std::move(UnderlyingSolver)) {}
 
   std::error_code infer(const std::vector<InstMapping> &PCs,
-                        Inst *LHS, Inst *&RHS, const InstOrigin *O,
-                        InstContext &IC) {
+                        Inst *LHS, Inst *&RHS, InstContext &IC) {
     std::string Repl = GetReplacementLHSString(PCs, LHS);
     const auto &ent = InferCache.find(Repl);
     if (ent == InferCache.end()) {
       ++MemMissesInfer;
-      std::error_code EC = UnderlyingSolver->infer(PCs, LHS, RHS, O, IC);
+      std::error_code EC = UnderlyingSolver->infer(PCs, LHS, RHS, IC);
       std::string RHSStr;
       if (!EC && RHS) {
         assert(RHS->K == Inst::Const);
@@ -182,99 +176,41 @@ public:
 
 };
 
-class RedisCachingSolver : public Solver {
+class ExternalCachingSolver : public Solver {
   std::unique_ptr<Solver> UnderlyingSolver;
-  redisContext *ctx;
+  KVStore *KV;
 
 public:
-  RedisCachingSolver(std::unique_ptr<Solver> UnderlyingSolver)
-      : UnderlyingSolver(std::move(UnderlyingSolver)) {
-
-    // get these from cmd line?
-    const char *hostname = "127.0.0.1";
-    int port = 6379;
-
-    struct timeval timeout = { 1, 500000 }; // 1.5 seconds
-    ctx = redisConnectWithTimeout(hostname, port, timeout);
-    if (!ctx) {
-      llvm::report_fatal_error("Can't allocate redis context\n");
-    }
-    if (ctx->err) {
-      llvm::report_fatal_error((std::string)"Redis connection error: " +
-                               ctx->errstr + "\n");
-    }
+  ExternalCachingSolver(std::unique_ptr<Solver> UnderlyingSolver, KVStore *KV)
+      : UnderlyingSolver(std::move(UnderlyingSolver)), KV(KV) {
   }
 
   std::error_code infer(const std::vector<InstMapping> &PCs,
-                        Inst *LHS, Inst *&RHS, const InstOrigin *O,
-                        InstContext &IC) {
+                        Inst *LHS, Inst *&RHS, InstContext &IC) {
     std::string LHSStr = GetReplacementLHSString(PCs, LHS);
-
-    if (StaticProfile) {
-      std::string Str;
-      llvm::raw_string_ostream Loc(Str);
-      if (O) {
-        Instruction *I = O->getInstruction();
-        I->getDebugLoc().print(I->getContext(), Loc);
-      }
-      std::string HField = "sprofile " + Loc.str();
-      redisReply *reply = (redisReply *)redisCommand(ctx, "HINCRBY %s %s 1",
-          LHSStr.c_str(), HField.c_str());
-      if (!reply || ctx->err) {
-        llvm::report_fatal_error((std::string)"Redis error: " + ctx->errstr);
-      }
-      if (reply->type != REDIS_REPLY_INTEGER) {
-        llvm::report_fatal_error(
-            "Redis protocol error for static profile, didn't expect reply type "
-            + std::to_string(reply->type));
-      }
-      freeReplyObject(reply);
-    }
-
-    redisReply *reply = (redisReply *)redisCommand(ctx, "HGET %s result",
-                                                   LHSStr.c_str());
-    if (!reply || ctx->err) {
-      llvm::report_fatal_error((std::string)"Redis error: " + ctx->errstr);
-    }
-    if (reply->type == REDIS_REPLY_NIL) {
-      freeReplyObject(reply);
-      ++RedisMisses;
-      std::error_code EC = UnderlyingSolver->infer(PCs, LHS, RHS, O, IC);
-      std::string RHSStr;
-      if (!EC && RHS) {
-        assert(RHS->K == Inst::Const);
-        RHSStr = GetReplacementRHSString(RHS->Val);
-      }
-      reply = (redisReply *)redisCommand(ctx, "HSET %s result %s",
-                                         LHSStr.c_str(), RHSStr.c_str());
-      if (!reply || ctx->err) {
-        llvm::report_fatal_error((std::string)"Redis error: " + ctx->errstr);
-      }
-      if (reply->type != REDIS_REPLY_INTEGER) {
-        llvm::report_fatal_error(
-            "Redis protocol error for cache fill, didn't expect reply type " +
-            std::to_string(reply->type));
-      }
-      freeReplyObject(reply);
-      return EC;
-    } else if (reply->type == REDIS_REPLY_STRING) {
-      ++RedisHits;
-      std::string ES;
-      StringRef S = reply->str;
+    std::string S;
+    if (KV->hGet(LHSStr, "result", S)) {
+      ++ExternalHits;
       if (S == "") {
         RHS = 0;
       } else {
+        std::string ES;
         ParsedReplacement R = ParseReplacementRHS(IC, "<cache>", S, ES);
         if (ES != "")
           return std::make_error_code(std::errc::protocol_error);
         RHS = R.Mapping.RHS;
       }
-      freeReplyObject(reply);
       return std::error_code();
     } else {
-      llvm::report_fatal_error(
-          "Redis protocol error for cache lookup, didn't expect reply type " +
-          std::to_string(reply->type));
+      ++ExternalMisses;
+      std::error_code EC = UnderlyingSolver->infer(PCs, LHS, RHS, IC);
+      std::string RHSStr;
+      if (!EC && RHS) {
+        assert(RHS->K == Inst::Const);
+        RHSStr = GetReplacementRHSString(RHS->Val);
+      }
+      KV->hSet(LHSStr, "result", RHSStr);
+      return EC;
     }
   }
 
@@ -282,7 +218,7 @@ public:
                           InstMapping Mapping, bool &IsValid,
                           std::vector<std::pair<Inst *, llvm::APInt>> *Model) {
     // N.B. we decided that since the important clients have moved to infer(),
-    // we'll no longer support Redis-based caching for isValid()
+    // we'll no longer support external caching for isValid()
     return UnderlyingSolver->isValid(PCs, Mapping, IsValid, Model);
   }
 
@@ -309,10 +245,10 @@ std::unique_ptr<Solver> createMemCachingSolver(
       new MemCachingSolver(std::move(UnderlyingSolver)));
 }
 
-std::unique_ptr<Solver> createRedisCachingSolver(
-    std::unique_ptr<Solver> UnderlyingSolver) {
+std::unique_ptr<Solver> createExternalCachingSolver(
+    std::unique_ptr<Solver> UnderlyingSolver, KVStore *KV) {
   return std::unique_ptr<Solver>(
-      new RedisCachingSolver(std::move(UnderlyingSolver)));
+      new ExternalCachingSolver(std::move(UnderlyingSolver), KV));
 }
 
 }

--- a/lib/KVStore/KVStore.cpp
+++ b/lib/KVStore/KVStore.cpp
@@ -1,0 +1,124 @@
+// Copyright 2014 The Souper Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "souper/KVStore/KVStore.h"
+
+#include "llvm/Support/CommandLine.h"
+#include "hiredis.h"
+
+using namespace llvm;
+using namespace souper;
+
+static cl::opt<unsigned> RedisPort("souper-redis-port", cl::init(6379),
+    cl::desc("Redis server port (default=6379)"));
+
+namespace souper {
+
+class KVStore::KVImpl {
+  redisContext *Ctx;
+public:
+  KVImpl();
+  ~KVImpl();
+  void hIncrBy(llvm::StringRef Key, llvm::StringRef Field, int Incr);
+  bool hGet(llvm::StringRef Key, llvm::StringRef Field, std::string &Value);
+  void hSet(llvm::StringRef Key, llvm::StringRef Field, llvm::StringRef Value);
+};
+
+KVStore::KVImpl::KVImpl() {
+  const char *hostname = "127.0.0.1";
+  struct timeval Timeout = { 1, 500000 }; // 1.5 seconds
+  Ctx = redisConnectWithTimeout(hostname, RedisPort, Timeout);
+  if (!Ctx) {
+    llvm::report_fatal_error("Can't allocate redis context\n");
+  }
+  if (Ctx->err) {
+    llvm::report_fatal_error((llvm::StringRef)"Redis connection error: " +
+                             Ctx->errstr + "\n");
+  }
+}
+
+KVStore::KVImpl::~KVImpl() {
+  redisFree(Ctx);
+}
+
+void KVStore::KVImpl::hIncrBy(llvm::StringRef Key, llvm::StringRef Field,
+                              int Incr) {
+  redisReply *reply = (redisReply *)redisCommand(Ctx, "HINCRBY %s %s 1",
+                                                 Key.data(), Field.data());
+  if (!reply || Ctx->err) {
+    llvm::report_fatal_error((llvm::StringRef)"Redis error: " + Ctx->errstr);
+  }
+  if (reply->type != REDIS_REPLY_INTEGER) {
+    llvm::report_fatal_error(
+        "Redis protocol error for static profile, didn't expect reply type "
+        + std::to_string(reply->type));
+  }
+  freeReplyObject(reply);
+}
+
+bool KVStore::KVImpl::hGet(llvm::StringRef Key, llvm::StringRef Field,
+                           std::string &Value) {
+  redisReply *reply = (redisReply *)redisCommand(Ctx, "HGET %s %s", Key.data(),
+                                                 Field.data());
+  if (!reply || Ctx->err) {
+    llvm::report_fatal_error((llvm::StringRef)"Redis error: " + Ctx->errstr);
+  }
+  if (reply->type == REDIS_REPLY_NIL) {
+    freeReplyObject(reply);
+    return false;
+  } else if (reply->type == REDIS_REPLY_STRING) {
+    Value = reply->str;
+    freeReplyObject(reply);
+    return true;
+  } else {
+    llvm::report_fatal_error(
+        "Redis protocol error for cache lookup, didn't expect reply type " +
+        std::to_string(reply->type));
+  }
+}
+
+void KVStore::KVImpl::hSet(llvm::StringRef Key, llvm::StringRef Field,
+                              llvm::StringRef Value) {
+  redisReply *reply = (redisReply *)redisCommand(Ctx, "HSET %s %s %s",
+      Key.data(), Field.data(), Value.data());
+  if (!reply || Ctx->err) {
+    llvm::report_fatal_error((llvm::StringRef)"Redis error: " + Ctx->errstr);
+  }
+  if (reply->type != REDIS_REPLY_INTEGER) {
+    llvm::report_fatal_error(
+        "Redis protocol error for cache fill, didn't expect reply type " +
+        std::to_string(reply->type));
+  }
+  freeReplyObject(reply);
+}
+
+KVStore::KVStore() : Impl (new KVImpl) {}
+
+KVStore::~KVStore() {}
+
+void KVStore::hIncrBy(llvm::StringRef Key, llvm::StringRef Field, int Incr) {
+  Impl->hIncrBy(Key, Field, Incr);
+}
+
+bool KVStore::hGet(llvm::StringRef Key, llvm::StringRef Field,
+                   std::string &Value) {
+  return Impl->hGet(Key, Field, Value);
+}
+
+void KVStore::hSet(llvm::StringRef Key, llvm::StringRef Field,
+                   llvm::StringRef Value) {
+  Impl->hSet(Key, Field, Value);
+}
+
+}

--- a/lib/Tool/CandidateMapUtils.cpp
+++ b/lib/Tool/CandidateMapUtils.cpp
@@ -18,8 +18,13 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
+#include "souper/KVStore/KVStore.h"
 #include "souper/SMTLIB2/Solver.h"
+
+using namespace llvm;
 
 void souper::AddToCandidateMap(CandidateMap &M,
                                const CandidateReplacement &CR) {
@@ -41,7 +46,8 @@ void souper::AddModuleToCandidateMap(InstContext &IC, ExprBuilderContext &EBC,
 namespace souper {
 
 bool SolveCandidateMap(llvm::raw_ostream &OS, CandidateMap &M,
-                       Solver *S, InstContext &IC) {
+                       Solver *S, InstContext &IC, bool StaticProfile,
+                       KVStore *KV) {
   if (S) {
     OS << "; Listing valid replacements.\n";
     OS << "; Using solver: " << S->getName() << '\n';
@@ -64,9 +70,20 @@ bool SolveCandidateMap(llvm::raw_ostream &OS, CandidateMap &M,
       if (Profile[I] == 0)
         continue;
       auto &Cand = M[I];
+
+      if (StaticProfile) {
+        std::string Str;
+        llvm::raw_string_ostream Loc(Str);
+        Instruction *I = Cand.Origin.getInstruction();
+        I->getDebugLoc().print(I->getContext(), Loc);
+        std::string HField = "sprofile " + Loc.str();
+        KV->hIncrBy(GetReplacementLHSString(Cand.PCs, Cand.Mapping.LHS), HField,
+                    1);
+      }
+
       Inst *RHS;
       if (std::error_code EC =
-              S->infer(Cand.PCs, Cand.Mapping.LHS, RHS, &Cand.Origin, IC)) {
+              S->infer(Cand.PCs, Cand.Mapping.LHS, RHS, IC)) {
         llvm::errs() << "Unable to query solver: " << EC.message() << '\n';
         return false;
       }
@@ -103,7 +120,7 @@ bool CheckCandidateMap(llvm::Module &Mod, CandidateMap &M, Solver *S,
   for (auto &Cand : M) {
     Inst *RHS;
     if (std::error_code EC =
-            S->infer(Cand.PCs, Cand.Mapping.LHS, RHS, &Cand.Origin, IC)) {
+            S->infer(Cand.PCs, Cand.Mapping.LHS, RHS, IC)) {
       llvm::errs() << "Unable to query solver: " << EC.message() << '\n';
       return false;
     }

--- a/test/Pass/clang-pass-profile.c
+++ b/test/Pass/clang-pass-profile.c
@@ -1,6 +1,6 @@
 // REQUIRES: solver
 
-// RUN: env SOUPER_NO_EXTERNAL_CACHE=1 SOUPER_PROFILE=1 SOUPER_SOLVER=%solver %sclang -O %s -o %t
+// RUN: env SOUPER_NO_EXTERNAL_CACHE=1 SOUPER_DYNAMIC_PROFILE=1 SOUPER_SOLVER=%solver %sclang -O %s -o %t
 
 // RUN: env SOUPER_PROFILE_TO_STDOUT=1 %t 0 | FileCheck %s -check-prefix=ARG0
 // ARG0: count = 0

--- a/test/Pass/dump-all-replacements.ll
+++ b/test/Pass/dump-all-replacements.ll
@@ -1,0 +1,14 @@
+; REQUIRES: solver
+
+; RUN: opt -load %pass -souper %solver -S -o - %s -souper-debug -souper-debug-level=2 > %t 2>&1
+; RUN: FileCheck %s < %t
+
+; Check that the souper pass dumps all replacements.
+
+; CHECK: Listing all replacements for foo
+; CHECK: 0:i1 = eq 1:i32, 1:i32
+define void @foo() {
+entry:
+  %t = icmp eq i32 1, 1
+  ret void
+}

--- a/test/Solver/div-by-zero1.ll
+++ b/test/Solver/div-by-zero1.ll
@@ -1,0 +1,83 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+define void @fn1() {
+entry:
+  %d1 = sdiv i32 1, 0 
+  %b1 = icmp eq i32 %d1, 0, !expected !1
+  br i1 %b1, label %cond.true, label %cond.false
+
+  %d2 = sdiv i32 0, 0 
+  %b2 = icmp eq i32 %d2, 0, !expected !1
+  br i1 %b2, label %cond.true, label %cond.false
+
+  %d3 = sdiv i32 0, undef
+  %b3 = icmp eq i32 %d3, 0, !expected !1
+  br i1 %b3, label %cond.true, label %cond.false
+
+  %d4 = sdiv i32 undef, undef
+  %b4 = icmp eq i32 %d4, 0, !expected !1
+  br i1 %b4, label %cond.true, label %cond.false
+
+  %d5 = udiv i32 1, 0 
+  %b5 = icmp eq i32 %d5, 0, !expected !1
+  br i1 %b5, label %cond.true, label %cond.false
+
+  %d6 = udiv i32 0, 0 
+  %b6 = icmp eq i32 %d6, 0, !expected !1
+  br i1 %b6, label %cond.true, label %cond.false
+
+  %d7 = udiv i32 0, undef
+  %b7 = icmp eq i32 %d7, 0, !expected !1
+  br i1 %b7, label %cond.true, label %cond.false
+
+  %d8 = udiv i32 0, undef
+  %b8 = icmp eq i32 %d8, 0, !expected !1
+  br i1 %b8, label %cond.true, label %cond.false
+
+  %d9 = urem i32 1, 0 
+  %b9 = icmp eq i32 %d9, 0, !expected !1
+  br i1 %b9, label %cond.true, label %cond.false
+
+  %d10 = urem i32 0, 0 
+  %b10 = icmp eq i32 %d10, 0, !expected !1
+  br i1 %b10, label %cond.true, label %cond.false
+
+  %d11 = urem i32 0, undef
+  %b11 = icmp eq i32 %d11, 0, !expected !1
+  br i1 %b11, label %cond.true, label %cond.false
+
+  %d12 = urem i32 0, undef
+  %b12 = icmp eq i32 %d12, 0, !expected !1
+  br i1 %b12, label %cond.true, label %cond.false
+
+  %d13 = srem i32 1, 0 
+  %b13 = icmp eq i32 %d13, 0, !expected !1
+  br i1 %b13, label %cond.true, label %cond.false
+
+  %d14 = srem i32 0, 0 
+  %b14 = icmp eq i32 %d14, 0, !expected !1
+  br i1 %b14, label %cond.true, label %cond.false
+
+  %d15 = srem i32 0, undef
+  %b15 = icmp eq i32 %d15, 0, !expected !1
+  br i1 %b15, label %cond.true, label %cond.false
+
+  %d16 = srem i32 0, undef
+  %b16 = icmp eq i32 %d16, 0, !expected !1
+  br i1 %b16, label %cond.true, label %cond.false
+
+cond.true:
+  br label %return
+
+cond.false:
+  br label %return
+
+return:
+  ret void
+}
+
+!1 = metadata !{ i1 1 }
+

--- a/test/Solver/div-by-zero2.ll
+++ b/test/Solver/div-by-zero2.ll
@@ -1,0 +1,107 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+define void @fn1() {
+entry:
+  %s11 = zext i8 undef to i16
+  %s12 = sext i16 %s11 to i32
+  %d1 = sdiv i32 1, %s12
+  %b1 = icmp eq i32 %d1, 0, !expected !1
+  br i1 %b1, label %cond.true, label %cond.false
+
+  %s21 = sext i8 undef to i16
+  %s22 = zext i16 %s21 to i32
+  %d2 = sdiv i32 0, %s22
+  %b2 = icmp eq i32 %d2, 0, !expected !1
+  br i1 %b2, label %cond.true, label %cond.false
+
+  %s31 = sext i8 0 to i16
+  %s32 = zext i16 %s31 to i32
+  %d3 = sdiv i32 0, %s32
+  %b3 = icmp eq i32 %d3, 0, !expected !1
+  br i1 %b3, label %cond.true, label %cond.false
+
+  %s41 = zext i8 0 to i16
+  %s42 = sext i16 %s41 to i32
+  %d4 = sdiv i32 undef, %s42
+  %b4 = icmp eq i32 %d4, 0, !expected !1
+  br i1 %b4, label %cond.true, label %cond.false
+
+  %s51 = zext i8 undef to i16
+  %s52 = zext i16 %s51 to i32
+  %d5 = udiv i32 1, %s52
+  %b5 = icmp eq i32 %d5, 0, !expected !1
+  br i1 %b5, label %cond.true, label %cond.false
+
+  %s61 = zext i8 0 to i16
+  %s62 = zext i16 %s61 to i32
+  %d6 = udiv i32 0, %s62
+  %b6 = icmp eq i32 %d6, 0, !expected !1
+  br i1 %b6, label %cond.true, label %cond.false
+
+  %s71 = zext i8 undef to i16
+  %s72 = zext i16 %s71 to i32
+  %d7 = udiv i32 0, %s72
+  %b7 = icmp eq i32 %d7, 0, !expected !1
+  br i1 %b7, label %cond.true, label %cond.false
+
+  %s81 = zext i8 0 to i16
+  %s82 = zext i16 %s81 to i32
+  %d8 = udiv i32 0, %s82
+  %b8 = icmp eq i32 %d8, 0, !expected !1
+  br i1 %b8, label %cond.true, label %cond.false
+
+  %ss1 = zext i1 0 to i8
+  %ss2 = zext i8 %ss1 to i16
+  %ss3 = sext i8 %ss1 to i16
+  %ss4 = zext i16 %ss2 to i32
+  %ss5 = sext i16 %ss2 to i32
+  %ss6 = sext i16 %ss2 to i32
+  %ss7 = zext i16 %ss2 to i32
+
+  %d9 = urem i32 1, 0 
+  %b9 = icmp eq i32 %d9, %ss4, !expected !1
+  br i1 %b9, label %cond.true, label %cond.false
+
+  %d10 = urem i32 0, 0 
+  %b10 = icmp eq i32 %d10, %ss5, !expected !1
+  br i1 %b10, label %cond.true, label %cond.false
+
+  %d11 = urem i32 0, undef
+  %b11 = icmp eq i32 %d11, %ss6, !expected !1
+  br i1 %b11, label %cond.true, label %cond.false
+
+  %d12 = urem i32 0, undef
+  %b12 = icmp eq i32 %d12, %ss7, !expected !1
+  br i1 %b12, label %cond.true, label %cond.false
+
+  %d13 = srem i32 1, 0 
+  %b13 = icmp eq i32 %d13, %ss7, !expected !1
+  br i1 %b13, label %cond.true, label %cond.false
+
+  %d14 = srem i32 0, 0 
+  %b14 = icmp eq i32 %d14, %ss6, !expected !1
+  br i1 %b14, label %cond.true, label %cond.false
+
+  %d15 = srem i32 0, undef
+  %b15 = icmp eq i32 %d15, %ss5, !expected !1
+  br i1 %b15, label %cond.true, label %cond.false
+
+  %d16 = srem i32 0, undef
+  %b16 = icmp eq i32 %d16, %ss4, !expected !1
+  br i1 %b16, label %cond.true, label %cond.false
+
+cond.true:
+  br label %return
+
+cond.false:
+  br label %return
+
+return:
+  ret void
+}
+
+!1 = metadata !{ i1 1 }
+

--- a/test/Solver/div-by-zero3.ll
+++ b/test/Solver/div-by-zero3.ll
@@ -1,0 +1,99 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+define void @fn1() {
+entry:
+  %s1 = add i32 0, 0
+  %d1 = sdiv i32 1, %s1
+  %b1 = icmp eq i32 %d1, 0, !expected !1
+  br i1 %b1, label %cond.true, label %cond.false
+
+  %s2 = sub i32 0, 0
+  %d2 = sdiv i32 1, %s2
+  %b2 = icmp eq i32 %d2, 0, !expected !1
+  br i1 %b2, label %cond.true, label %cond.false
+
+  %s3 = sub i32 10, 10
+  %d3 = sdiv i32 1, %s3 
+  %b3 = icmp eq i32 %d3, 0, !expected !1
+  br i1 %b3, label %cond.true, label %cond.false
+
+  %s4 = mul i32 0, 10
+  %d4 = sdiv i32 1, %s4
+  %b4 = icmp eq i32 %d4, 0, !expected !1
+  br i1 %b4, label %cond.true, label %cond.false
+
+  %s5 = mul i32 10, 0
+  %d5 = udiv i32 1, %s5
+  %b5 = icmp eq i32 %d5, 0, !expected !1
+  br i1 %b5, label %cond.true, label %cond.false
+
+  %s6 = mul i32 0, undef
+  %d6 = udiv i32 1, %s6
+  %b6 = icmp eq i32 %d6, 0, !expected !1
+  br i1 %b6, label %cond.true, label %cond.false
+
+  %s7 = sub i32 undef, 0
+  %d7 = udiv i32 1, %s7
+  %b7 = icmp eq i32 %d7, 0, !expected !1
+  br i1 %b7, label %cond.true, label %cond.false
+
+  %s8 = shl i32 0, 1
+  %d8 = udiv i32 1, %s8
+  %b8 = icmp eq i32 %d8, 0, !expected !1
+  br i1 %b8, label %cond.true, label %cond.false
+
+  %s9 = sub i32 undef, undef
+  %d9 = urem i32 1, %s9
+  %b9 = icmp eq i32 %d9, 0, !expected !1
+  br i1 %b9, label %cond.true, label %cond.false
+
+  %s10 = mul i32 undef, 0
+  %d10 = urem i32 1, %s10
+  %b10 = icmp eq i32 %d10, 0, !expected !1
+  br i1 %b10, label %cond.true, label %cond.false
+
+  %s11 = udiv i32 0, 1
+  %d11 = urem i32 1, %s11
+  %b11 = icmp eq i32 %d11, 0, !expected !1
+  br i1 %b11, label %cond.true, label %cond.false
+
+  %s12 = sdiv i32 undef, 1
+  %d12 = urem i32 1, %s12
+  %b12 = icmp eq i32 %d12, 0, !expected !1
+  br i1 %b12, label %cond.true, label %cond.false
+
+  %s13 = srem i32 undef, 1
+  %d13 = srem i32 1, %s13
+  %b13 = icmp eq i32 %d13, 0, !expected !1
+  br i1 %b13, label %cond.true, label %cond.false
+
+  %s14 = urem i32 0, 1
+  %d14 = srem i32 1, %s14
+  %b14 = icmp eq i32 %d14, 0, !expected !1
+  br i1 %b14, label %cond.true, label %cond.false
+
+  %s15 = lshr i32 0, 1
+  %d15 = srem i32 1, %s15
+  %b15 = icmp eq i32 %d15, 0, !expected !1
+  br i1 %b15, label %cond.true, label %cond.false
+
+  %s16 = shl i32 0, 1
+  %d16 = srem i32 1, %s16
+  %b16 = icmp eq i32 %d16, 0, !expected !1
+  br i1 %b16, label %cond.true, label %cond.false
+
+cond.true:
+  br label %return
+
+cond.false:
+  br label %return
+
+return:
+  ret void
+}
+
+!1 = metadata !{ i1 1 }
+

--- a/tools/clang-souper.cpp
+++ b/tools/clang-souper.cpp
@@ -50,6 +50,8 @@ int main(int argc, const char **argv) {
       getGlobalContext(), IC, EBC, OwnedMods, CandMap));
   Tool.run(Factory.get());
 
-  std::unique_ptr<Solver> S = GetSolverFromArgs();
-  return SolveCandidateMap(llvm::outs(), CandMap, S.get(), IC) ? 0 : 1;
+  KVStore *KV = 0;
+  std::unique_ptr<Solver> S = GetSolverFromArgs(KV);
+  return SolveCandidateMap(llvm::outs(), CandMap, S.get(), IC, false, KV)
+    ? 0 : 1;
 }

--- a/tools/souper-check.cpp
+++ b/tools/souper-check.cpp
@@ -52,7 +52,7 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
 
   if (InferRHS) {
     if (std::error_code EC = S->infer(Rep.PCs, Rep.Mapping.LHS, Rep.Mapping.RHS,
-                                      0, IC)) {
+                                      IC)) {
       llvm::errs() << EC.message() << '\n';
       return 1;
     }
@@ -101,7 +101,8 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
 
 int main(int argc, char **argv) {
   cl::ParseCommandLineOptions(argc, argv);
-  std::unique_ptr<Solver> S = GetSolverFromArgs();
+  KVStore *KV = 0;
+  std::unique_ptr<Solver> S = GetSolverFromArgs(KV);
   if (!S) {
     llvm::errs() << "Specify a solver\n";
     return 1;

--- a/tools/souper.cpp
+++ b/tools/souper.cpp
@@ -44,6 +44,9 @@ static cl::opt<std::string>
 OutputFilename("o", cl::desc("Override output filename"),
     cl::init(""), cl::value_desc("filename"));
 
+static cl::opt<bool> StaticProfile("souper-static-profile", cl::init(false),
+    cl::desc("Static profiling of Souper optimizations (default=false)"));
+
 static cl::opt<bool>
 Check("check", cl::desc("Check input for expected results"),
     cl::init(false));
@@ -90,7 +93,10 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  std::unique_ptr<Solver> S = GetSolverFromArgs();
+  KVStore *KV = 0;
+  std::unique_ptr<Solver> S = GetSolverFromArgs(KV);
+  if (StaticProfile && !KV)
+    KV = new KVStore;
 
   InstContext IC;
   ExprBuilderContext EBC;
@@ -101,6 +107,7 @@ int main(int argc, char **argv) {
   if (Check) {
     return CheckCandidateMap(*M.get(), CandMap, S.get(), IC) ? 0 : 1;
   } else {
-    return SolveCandidateMap(llvm::outs(), CandMap, S.get(), IC) ? 0 : 1;
+    return SolveCandidateMap(llvm::outs(), CandMap, S.get(), IC, StaticProfile,
+                             KV) ? 0 : 1;
   }
 }

--- a/tools/souperweb-backend.cpp
+++ b/tools/souperweb-backend.cpp
@@ -30,6 +30,8 @@ using namespace souper;
 
 extern "C" int boolector_main(int argc, char **argv);
 
+KVStore *KV;
+
 void SolveIR(std::unique_ptr<MemoryBuffer> MB, Solver *S) {
   SMDiagnostic Err;
   if (std::unique_ptr<Module> M =
@@ -40,7 +42,7 @@ void SolveIR(std::unique_ptr<MemoryBuffer> MB, Solver *S) {
 
     AddModuleToCandidateMap(IC, EBC, CandMap, M.get());
 
-    SolveCandidateMap(llvm::outs(), CandMap, S, IC);
+    SolveCandidateMap(llvm::outs(), CandMap, S, IC, false, KV);
   } else {
     Err.print(0, llvm::errs(), false);
   }
@@ -86,7 +88,7 @@ static llvm::cl::opt<std::string> Action("action", llvm::cl::init(""));
 
 int main(int argc, char **argv) {
   cl::ParseCommandLineOptions(argc, argv);
-  std::unique_ptr<Solver> S = GetSolverFromArgs();
+  std::unique_ptr<Solver> S = GetSolverFromArgs(KV);
 
   auto MB = MemoryBuffer::getSTDIN();
   if (MB) {

--- a/utils/reduce.in
+++ b/utils/reduce.in
@@ -36,7 +36,7 @@ sub check ($) {
     close INF;
     close $fh;
     unlink $tmpfn;
-    return 0 if ($s2 eq "LGTM");
+    return 0 if ($s2 =~ "LGTM");
     return 1;
 }
 
@@ -254,6 +254,5 @@ my $x = "";
 while (my $line = <STDIN>) {
     $x .= $line;
 }
+die "initial check fails" unless check($x) == 0;
 print pretty(reduce($x));
-
-print "foo\n";

--- a/utils/sclang.in
+++ b/utils/sclang.in
@@ -68,8 +68,12 @@ if ($souper) {
         push @ARGV, ("-mllvm", "-stats");
     }
 
-    if ($ENV{"SOUPER_PROFILE"}) {
-        push @ARGV, ("-g", "-mllvm", "-souper-profile-opts");
+    if ($ENV{"SOUPER_STATIC_PROFILE"}) {
+        push @ARGV, ("-mllvm", "-souper-static-profile");
+    }
+
+    if ($ENV{"SOUPER_DYNAMIC_PROFILE"}) {
+        push @ARGV, ("-g", "-mllvm", "-souper-dynamic-profile");
         if (linkp()) {
             push @ARGV, ("@PROFILE_LIBRARY@", "@HIREDIS_LIBRARY@");
         }


### PR DESCRIPTION
hide Redis in a KVStore class

perform static profiling properly 

N.B. static profile counts for non-optimizations are off by 5x for the opt pass, because the pass runs 5 times. I don't think we care since optimizations and non-optimizations will always be ranked separately. profiling of non-optimizations is a niche use case anyway.
