### PR TITLE
Blockpc

### DIFF
--- a/include/souper/Extractor/Candidates.h
+++ b/include/souper/Extractor/Candidates.h
@@ -62,6 +62,11 @@ struct CandidateReplacement {
   /// The path conditions relevant to this replacement.
   std::vector<InstMapping> PCs;
 
+  /// The block path conditions relevant to this replacement.
+  /// A BlockPC has the same semantics as a PC, except that the PC only applies
+  /// if the given predecessor of the given block is chosen.
+  BlockPCs BPCs;
+
   void printFunction(llvm::raw_ostream &Out) const;
   void printLHS(llvm::raw_ostream &Out, ReplacementContext &Context,
                 bool printNames = false) const;
@@ -73,6 +78,7 @@ struct BlockCandidateSet {
   llvm::BasicBlock *Origin;
 
   std::vector<InstMapping> PCs;
+  BlockPCs BPCs;
   std::vector<CandidateReplacement> Replacements;
 };
 

--- a/include/souper/Extractor/KLEEBuilder.h
+++ b/include/souper/Extractor/KLEEBuilder.h
@@ -29,9 +29,11 @@ struct CandidateExpr {
   klee::ref<klee::Expr> E;
 };
 
-CandidateExpr GetCandidateExprForReplacement(const std::vector<InstMapping> &PCs,
+CandidateExpr GetCandidateExprForReplacement(const BlockPCs &BPCs,
+                                             const std::vector<InstMapping> &PCs,
                                              InstMapping Mapping);
-std::string BuildQuery(const std::vector<InstMapping> &PCs, InstMapping Mapping,
+std::string BuildQuery(const BlockPCs &BPCs,
+                       const std::vector<InstMapping> &PCs, InstMapping Mapping,
                        std::vector<Inst *> *ModelVars);
 
 }

--- a/include/souper/Extractor/Solver.h
+++ b/include/souper/Extractor/Solver.h
@@ -30,11 +30,11 @@ class Solver {
 public:
   virtual ~Solver();
   virtual std::error_code
-  infer(const std::vector<InstMapping> &PCs, Inst *LHS, Inst *&RHS,
-        InstContext &IC) = 0;
+  infer(const BlockPCs &BPCs, const std::vector<InstMapping> &PCs, 
+        Inst *LHS, Inst *&RHS, InstContext &IC) = 0;
   virtual std::error_code
-  isValid(const std::vector<InstMapping> &PCs, InstMapping Mapping,
-          bool &IsValid,
+  isValid(const BlockPCs &BPCs, const std::vector<InstMapping> &PCs, 
+          InstMapping Mapping, bool &IsValid,
           std::vector<std::pair<Inst *, llvm::APInt>> *Model) = 0;
   virtual std::string getName() = 0;
 };

--- a/include/souper/Parser/Parser.h
+++ b/include/souper/Parser/Parser.h
@@ -27,19 +27,22 @@ struct ParsedReplacement {
   /// The path conditions relevant to this replacement.
   std::vector<InstMapping> PCs;
 
+  /// The blockpc condtions relevant to this replacement.
+  BlockPCs BPCs;
+
   void print(llvm::raw_ostream &OS, bool printNames = false) const {
-    PrintReplacement(OS, PCs, Mapping, printNames);
+    PrintReplacement(OS, BPCs, PCs, Mapping, printNames);
   }
   std::string getString(bool printNames = false) const {
-    return GetReplacementString(PCs, Mapping, printNames);
+    return GetReplacementString(BPCs, PCs, Mapping, printNames);
   }
   void printLHS(llvm::raw_ostream &OS, ReplacementContext &Context,
                 bool printNames = false) const {
-    PrintReplacementLHS(OS, PCs, Mapping.LHS, Context, printNames);
+    PrintReplacementLHS(OS, BPCs, PCs, Mapping.LHS, Context, printNames);
   }
   std::string getLHSString(ReplacementContext &Context,
                            bool printNames = false) const {
-    return GetReplacementLHSString(PCs, Mapping.LHS, Context, printNames);
+    return GetReplacementLHSString(BPCs, PCs, Mapping.LHS, Context, printNames);
   }
   void printRHS(llvm::raw_ostream &OS, ReplacementContext &Context,
                 bool printNames = false) const {

--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <sstream>
 #include <unordered_set>
+#include <tuple>
 
 using namespace llvm;
 using namespace klee;
@@ -58,12 +59,12 @@ void CandidateReplacement::printFunction(llvm::raw_ostream &Out) const {
 void CandidateReplacement::printLHS(llvm::raw_ostream &Out,
                                     ReplacementContext &Context,
                                     bool printNames) const {
-  PrintReplacementLHS(Out, PCs, Mapping.LHS, Context, printNames);
+  PrintReplacementLHS(Out, BPCs, PCs, Mapping.LHS, Context, printNames);
 }
 
 void CandidateReplacement::print(llvm::raw_ostream &Out,
                                  bool printNames) const {
-  PrintReplacement(Out, PCs, Mapping, printNames);
+  PrintReplacement(Out, BPCs, PCs, Mapping, printNames);
 }
 
 namespace {
@@ -88,7 +89,9 @@ struct ExprBuilder {
   Inst *buildConstant(Constant *c);
   Inst *buildGEP(Inst *Ptr, gep_type_iterator begin, gep_type_iterator end);
   Inst *build(Value *V);
-  void addPathConditions(std::vector<InstMapping> &PCs, BasicBlock *BB);
+  void addPathConditions(BlockPCs &BPCs, std::vector<InstMapping> &PCs,
+                         std::unordered_set<Block *> &VisitedBlocks,
+                         BasicBlock *BB);
   Inst *get(Value *V);
 };
 
@@ -411,10 +414,64 @@ void emplace_back_dedup(std::vector<InstMapping> &PCs, Inst *LHS, Inst *RHS) {
   PCs.emplace_back(LHS, RHS);
 }
 
-void ExprBuilder::addPathConditions(std::vector<InstMapping> &PCs,
+// Collect path conditions for a basic block. 
+// There are two kinds of path conditions, which correspond to
+// two Souper instruction kinds, pc and blockpc, respectively.
+// (1) The PC condition is added when the given predecessor of
+//     the given basic block is chosen. For example, given the
+//     simple CFG below:
+//          B1
+//         /  \
+//       B2    B3
+//     The path conditions [B1->B2] and [B1->B3] will be added 
+//     to B2 and B3's PCs, respectively, because B1 can determine 
+//     the choice of either B2 or B3.
+// (2) The BlockPC condition handles cases where we don't know
+//     which predecessor would be chosen. In this case, we recursively
+//     process each predecessor of the given basic block until
+//     the PC condition (as defined above) is met. Then we add
+//     the this condition into the BlockPCs of the basic block from
+//     which we start our recursion. If a loop head or an entry
+//     point of an irreducible loop is encountered along any path, 
+//     we stash the collected BlockPCs (if there is any) and return.
+//     The following examples (without loops) describe the idea. 
+//     A simple example:
+//         B1
+//        /  \
+//            B2  B3
+//             \  /
+//              B4
+//     Suppose we are collecting BlockPCs for B4. Either
+//     B2 or B3 can reach B4, we cannot add them into B4's PC.
+//     Instead, we add whatever path conditions dominating B2 and
+//     B3 into B4's BlockPCs. In this simple case, we will have
+//     blockpc %B4, 0, s1, r1 // B1->B2
+//      
+// Now consider a more complex example:
+//            B1          B2
+//           /  \        /  \
+//               B3    B4
+//                \    /
+//                  B5        B6
+//                 /  \      /  \
+//                    B7   B8
+//                   /  \  /
+//                       B9
+// Suppose we are dealing with an instruction %i in B9, After we iterate all
+// basic blocks (in ExtractExprCandidates), we will have something like these:
+// blockpc %B5, 0, s1, r1 // B1->B3
+// blockpc %B5, 1, s2, r2 // B2->B4
+// ...
+// blockpc %B9, 0, s3, r3 // B5 -> B7
+// blockpc %B9, 1, s4, r4 // B6 -> B8
+// ...
+// cand %i, 1
+void ExprBuilder::addPathConditions(BlockPCs &BPCs,
+                                    std::vector<InstMapping> &PCs,
+                                    std::unordered_set<Block *> &VisitedBlocks,
                                     BasicBlock *BB) {
   if (auto Pred = BB->getSinglePredecessor()) {
-    addPathConditions(PCs, Pred);
+    addPathConditions(BPCs, PCs, VisitedBlocks, Pred);
     if (auto Branch = dyn_cast<BranchInst>(Pred->getTerminator())) {
       if (Branch->isConditional()) {
         emplace_back_dedup(
@@ -437,6 +494,37 @@ void ExprBuilder::addPathConditions(std::vector<InstMapping> &PCs,
         emplace_back_dedup(PCs, IC.getInst(Inst::And, 1, Cases),
                            IC.getConst(APInt(1, true)));
       }
+    }
+  } else {
+    // BB is the entry of the function.
+    if (pred_begin(BB) == pred_end(BB))
+      return;
+
+    BlockInfo &BI = EBC.BlockMap[BB];
+    // We encounter a loop entry point.
+    // FIXME: Basically, we stop at this point, i.e., we don't collect
+    // BlockPC's before loops. Maybe we should consider to resume from BB's
+    // immediate dominator. If we do, generate another pull request for this
+    // purpose.
+    if (!BI.B)
+      return;
+
+    // It's possible that we will re-visit a Block, e.g.,
+    //          \  /
+    //           B1
+    //          /  \
+    //         B2  B3
+    //          \  /
+    //           B4
+    if (VisitedBlocks.count(BI.B))
+      return;
+
+    VisitedBlocks.insert(BI.B);
+    for (unsigned i = 0; i < BI.Preds.size(); ++i) {
+      std::vector<InstMapping> PCs;
+      addPathConditions(BPCs, PCs, VisitedBlocks, BI.Preds[i]);
+      for (auto PC : PCs)
+        BPCs.emplace_back(BlockPCMapping(BI.B, i, PC));
     }
   }
 }
@@ -483,21 +571,42 @@ std::vector<Inst *> AddPCSets(const std::vector<InstMapping> &PCs,
   return PCSets;
 }
 
-// Return a vector of relevant PCs for a candidate, namely those whose variable
-// sets are in the same equivalence class as the candidate's.
-std::vector<InstMapping> GetRelevantPCs(const std::vector<InstMapping> &PCs,
-                                        const std::vector<Inst *> &PCSets,
-                                        InstClasses Vars,
-                                        InstMapping Cand) {
+// Similar to AddPCSets, add the variable sets of BlockPCs as equivalence
+// classes to Vars. Return a BPCSets of the same size as BPCs.
+std::vector<Inst *> AddBlockPCSets(const BlockPCs &BPCs, InstClasses &Vars) {
+  std::vector<Inst *> BPCSets(BPCs.size());
+  for (unsigned i = 0; i != BPCs.size(); ++i) {
+    llvm::DenseSet<Inst *> SeenInsts;
+    auto BPCLeader =
+        AddVarSet(Vars.member_end(), Vars, SeenInsts, BPCs[i].PC.LHS);
+    if (BPCLeader != Vars.member_end())
+      BPCSets[i] = *BPCLeader;
+  }
+  return BPCSets;
+}
+
+// Return vectors of relevant BlockPCs and PCs for a candidate, namely those
+// whose variable sets are in the same equivalence class as the candidate's.
+std::tuple<BlockPCs, std::vector<InstMapping>> GetRelevantPCs(
+    const BlockPCs &BPCs, const std::vector<InstMapping> &PCs,
+    const std::vector<Inst *> &BPCSets, const std::vector<Inst *> &PCSets,
+    InstClasses Vars, InstMapping Cand) {
+
   llvm::DenseSet<Inst *> SeenInsts;
   auto Leader = AddVarSet(Vars.member_end(), Vars, SeenInsts, Cand.LHS);
+
+  BlockPCs RelevantBPCs;
+  for (unsigned i = 0; i != BPCs.size(); ++i) {
+    if (BPCSets[i] != 0 && Vars.findLeader(BPCSets[i]) == Leader)
+      RelevantBPCs.emplace_back(BPCs[i]);
+  }
 
   std::vector<InstMapping> RelevantPCs;
   for (unsigned i = 0; i != PCs.size(); ++i) {
     if (PCSets[i] != 0 && Vars.findLeader(PCSets[i]) == Leader)
       RelevantPCs.emplace_back(PCs[i]);
   }
-  return RelevantPCs;
+  return std::make_tuple(RelevantBPCs, RelevantPCs);
 }
 
 void ExtractExprCandidates(Function &F, const LoopInfo *LI,
@@ -513,13 +622,16 @@ void ExtractExprCandidates(Function &F, const LoopInfo *LI,
         BCS->Replacements.emplace_back(&I, InstMapping(EB.get(&I), 0));
     }
     if (!BCS->Replacements.empty()) {
-      EB.addPathConditions(BCS->PCs, &BB);
+      std::unordered_set<Block *> VisitedBlocks;
+      EB.addPathConditions(BCS->BPCs, BCS->PCs, VisitedBlocks, &BB);
 
-      InstClasses Vars;
+      InstClasses Vars, BPCVars;
       auto PCSets = AddPCSets(BCS->PCs, Vars);
+      auto BPCSets = AddBlockPCSets(BCS->BPCs, BPCVars);
 
       for (auto &R : BCS->Replacements) {
-        R.PCs = GetRelevantPCs(BCS->PCs, PCSets, Vars, R.Mapping);
+        std::tie(R.BPCs, R.PCs) = 
+          GetRelevantPCs(BCS->BPCs, BCS->PCs, BPCSets, PCSets, Vars, R.Mapping);
       }
 
       Result.Blocks.emplace_back(std::move(BCS));

--- a/lib/Extractor/KLEEBuilder.cpp
+++ b/lib/Extractor/KLEEBuilder.cpp
@@ -46,7 +46,8 @@ using namespace souper;
 
 namespace {
 
-typedef std::unordered_map<Inst *, std::vector<ref<Expr> > > PhiMap;
+typedef std::unordered_map<Inst *, std::vector<ref<Expr>>> PhiMap;
+typedef std::map<unsigned, ref<Expr>> BlockPCPredMap;
 
 struct PhiPath {
   std::map<Block *, unsigned> BlockConstraints;
@@ -54,14 +55,21 @@ struct PhiPath {
   std::vector<Inst *> UBInsts;
 };
 
+struct BlockPCPhiPath {
+  std::map<Block *, unsigned> BlockConstraints;
+  std::vector<Inst *> Phis;
+  std::vector<ref<Expr>> PCs;
+};
+
 struct ExprBuilder {
-  ExprBuilder(std::vector<std::unique_ptr<Array> > &Arrays,
+  ExprBuilder(std::vector<std::unique_ptr<Array>> &Arrays,
               std::vector<Inst *> &ArrayVars)
       : Arrays(Arrays), ArrayVars(ArrayVars) {}
 
-  std::map<Block *, std::vector<ref<Expr> >> BlockPredMap;
-  std::map<Inst *, ref<Expr> > ExprMap;
-  std::map<Inst *, ref<Expr> > UBExprMap;
+  std::map<Block *, std::vector<ref<Expr>>> BlockPredMap;
+  std::map<Inst *, ref<Expr>> ExprMap;
+  std::map<Inst *, ref<Expr>> UBExprMap;
+  std::map<Block *, BlockPCPredMap> BlockPCMap;
   std::vector<std::unique_ptr<Array>> &Arrays;
   std::vector<Inst *> &ArrayVars;
   std::vector<Inst *> PhiInsts;
@@ -91,11 +99,19 @@ struct ExprBuilder {
   ref<Expr> getInstMapping(const InstMapping &IM);
   std::vector<ref<Expr >> getBlockPredicates(Inst *I);
   ref<Expr> getUBInstCondition();
-  ref<Expr> createPhiPred(const std::unique_ptr<PhiPath> &Path,
+  ref<Expr> getBlockPCs();
+  void setBlockPCMap(const BlockPCs &BPCs);
+  ref<Expr> createPhiPred(std::map<Block *, unsigned> &BlockConstraints,
                           Inst* Phi);
+  ref<Expr> createPathPred(Inst *CurrentPhi, std::vector<Inst *> &Phis,
+                           std::map<Block *, unsigned> &BlockConstraints,
+                           PhiMap &CachedPhis);
   void getUBPhiPaths(Inst *I, PhiPath *Current,
                      std::vector<std::unique_ptr<PhiPath>> &Paths,
                      PhiMap &CachedPhis);
+  void getBlockPCPhiPaths(Inst *I, BlockPCPhiPath *Current,
+                          std::vector<std::unique_ptr<BlockPCPhiPath>> &Paths,
+                          PhiMap &CachedPhis);
 };
 
 }
@@ -540,11 +556,11 @@ ref<Expr> ExprBuilder::getInstMapping(const InstMapping &IM) {
   return EqExpr::create(get(IM.LHS), get(IM.RHS));
 }
 
-std::vector<ref<Expr> > ExprBuilder::getBlockPredicates(Inst *I) {
+std::vector<ref<Expr>> ExprBuilder::getBlockPredicates(Inst *I) {
   assert(I->K == Inst::Phi && "not a phi inst");
   if (BlockPredMap.count(I->B))
     return BlockPredMap[I->B];
-  std::vector<ref<Expr> > PredExpr;
+  std::vector<ref<Expr>> PredExpr;
   const std::vector<Inst *> &Ops = I->orderedOps();
   for (unsigned J = 0; J < Ops.size()-1; ++J)
     PredExpr.push_back(makeSizedArrayRead(1, "blockpred", 0));
@@ -552,12 +568,12 @@ std::vector<ref<Expr> > ExprBuilder::getBlockPredicates(Inst *I) {
   return PredExpr;
 }
 
-ref<Expr> ExprBuilder::createPhiPred(const std::unique_ptr<PhiPath> &Path,
-                                     Inst* Phi) {
+ref<Expr> ExprBuilder::createPhiPred(
+    std::map<Block *, unsigned> &BlockConstraints, Inst* Phi) {
   assert((Phi->K == Inst::Phi) && "Must be a Phi instruction!");
 
   ref<Expr> Pred = klee::ConstantExpr::alloc(1, 1);
-  unsigned Num = Path->BlockConstraints[Phi->B];
+  unsigned Num = BlockConstraints[Phi->B];
   const auto &PredExpr = BlockPredMap[Phi->B];
   // Sanity checks
   assert(PredExpr.size() && "there must be path predicates for the UBs");
@@ -570,6 +586,34 @@ ref<Expr> ExprBuilder::createPhiPred(const std::unique_ptr<PhiPath> &Path,
   for (unsigned B = Num; B < PredExpr.size(); ++B)
     Pred = AndExpr::create(Pred, PredExpr[B]);
 
+  return Pred;
+}
+
+ref<Expr> ExprBuilder::createPathPred(
+    Inst *CurrentPhi, std::vector<Inst *> &Phis,
+    std::map<Block *, unsigned> &BlockConstraints, PhiMap &CachedPhis) {
+  ref<Expr> Pred = klee::ConstantExpr::alloc(1, 1);
+  for (const auto &Phi : Phis) {
+    if (Phi->Ops.size() == 1)
+      continue;
+    ref<Expr> PhiPred = createPhiPred(BlockConstraints, Phi);
+
+    PhiMap::iterator PI = CachedPhis.find(Phi);
+    assert((PI != CachedPhis.end()) && "No cached Phi?");
+    if (PI->first != CurrentPhi && PI->second.size() != 0) {
+      // Use cached Expr along each path which has UB Insts,
+      // and cache the expanded Expr for the current working Phi
+      for (auto CE : PI->second) {
+        PhiPred = AndExpr::create(CE, PhiPred);
+        CachedPhis[CurrentPhi].push_back(PhiPred);
+        Pred = AndExpr::create(Pred, PhiPred);
+      }
+    }
+    else {
+      CachedPhis[CurrentPhi].push_back(PhiPred);
+      Pred = AndExpr::create(Pred, PhiPred);
+    }
+  }
   return Pred;
 }
 
@@ -652,28 +696,8 @@ ref<Expr> ExprBuilder::getUBInstCondition() {
         UsedUBInsts.insert(I);
       }
       // Create path predicate
-      ref<Expr> Pred = klee::ConstantExpr::alloc(1, 1);
-      for (const auto &Phi : Path->Phis) {
-        if (Phi->Ops.size() == 1)
-          continue;
-        ref<Expr> PhiPred = createPhiPred(Path, Phi);
-
-        PhiMap::iterator PI = CachedPhis.find(Phi);
-        assert((PI != CachedPhis.end()) && "No cached Phi?");
-        if (PI->first != I && PI->second.size() != 0) {
-          // Use cached Expr along each path which has UB Insts,
-          // and cache the expanded Expr for the current working Phi
-          for (auto CE : PI->second) {
-            PhiPred = AndExpr::create(CE, PhiPred);
-            CachedPhis[I].push_back(PhiPred);
-            Pred = AndExpr::create(Pred, PhiPred);
-          }
-        }
-        else {
-          CachedPhis[I].push_back(PhiPred);
-          Pred = AndExpr::create(Pred, PhiPred);
-        }
-      }
+      ref<Expr> Pred = createPathPred(I, Path->Phis, Path->BlockConstraints,
+                                      CachedPhis);
       // Add predicate->UB constraint
       Result = AndExpr::create(Result, Expr::createImplies(Pred, Ante));
     }
@@ -750,9 +774,109 @@ void ExprBuilder::getUBPhiPaths(Inst *I, PhiPath *Current,
   }
 }
 
+void ExprBuilder::setBlockPCMap(const BlockPCs &BPCs) {
+  for (auto BPC : BPCs) {
+    assert(BPC.B && "Block is NULL!");
+    BlockPCPredMap &PCMap = BlockPCMap[BPC.B];
+    ref<Expr> PE = getInstMapping(BPC.PC);
+    auto I = PCMap.find(BPC.PredIdx);
+    if (I == PCMap.end()) {
+      PCMap[BPC.PredIdx] = PE;
+    }
+    else {
+      PCMap[BPC.PredIdx] = AndExpr::create(I->second, PE);
+    }
+  }
+}
+
+// Similar to the way we collect UB constraints. We could combine it with 
+// getUBInstCondition, because the workflow is quite similar. 
+// However, mixing two parts (one for UB constraints, one for BlockPCs)
+// may make the code less structured. If we see big performance overhead,
+// we may consider to combine these two parts together. 
+ref<Expr> ExprBuilder::getBlockPCs() {
+
+  PhiMap CachedPhis;
+  ref<Expr> Result = klee::ConstantExpr::create(1, Expr::Bool);
+  // For each Phi instruction
+  for (const auto &I : PhiInsts) {
+    assert((CachedPhis.count(I) == 0) && "We cannot revisit a cached Phi");
+    // Recursively collect BlockPCs
+    std::vector<std::unique_ptr<BlockPCPhiPath>> BlockPCPhiPaths;
+    BlockPCPhiPath *Current = new BlockPCPhiPath;
+    BlockPCPhiPaths.push_back(
+                        std::move(std::unique_ptr<BlockPCPhiPath>(Current)));
+    getBlockPCPhiPaths(I, Current, BlockPCPhiPaths, CachedPhis);
+    CachedPhis[I] = {};
+    // For each found path
+    for (const auto &Path : BlockPCPhiPaths) {
+      if (!Path->PCs.size())
+        continue;
+      // Aggregate collected BlockPC constraints
+      ref<Expr> Ante = klee::ConstantExpr::alloc(1, 1);
+      for (const auto &PC : Path->PCs) {
+        Ante = AndExpr::create(Ante, PC);
+      }
+      // Create path predicate
+      ref<Expr> Pred = createPathPred(I, Path->Phis, Path->BlockConstraints,
+                                      CachedPhis);
+      // Add predicate->UB constraint
+      Result = AndExpr::create(Result, Expr::createImplies(Pred, Ante));
+    }
+  }
+  return Result;
+}
+
+void ExprBuilder::getBlockPCPhiPaths(
+    Inst *I, BlockPCPhiPath *Current,
+    std::vector<std::unique_ptr<BlockPCPhiPath>> &Paths, PhiMap &CachedPhis) {
+
+  const std::vector<Inst *> &Ops = I->orderedOps();
+  if (I->K != Inst::Phi) {
+    for (unsigned J = 0; J < Ops.size(); ++J)
+      getBlockPCPhiPaths(Ops[J], Current, Paths, CachedPhis);
+    return;
+  }
+
+  // Early terminate because this phi has been processed.
+  // We will use its cached predicates.
+  if (CachedPhis.count(I))
+    return;
+  Current->Phis.push_back(I);
+  // Based on the dependency chain, looks like we would never
+  // encounter this case.
+  assert(!Current->BlockConstraints.count(I->B) && 
+         "Basic block has been added into BlockConstraints!");
+  std::vector<BlockPCPhiPath *> Tmp = { Current };
+  // Create copies of the current path
+  for (unsigned J = 1; J < Ops.size(); ++J) {
+    BlockPCPhiPath *New = new BlockPCPhiPath;
+    *New = *Current;
+    New->BlockConstraints[I->B] = J;
+    Paths.push_back(std::move(std::unique_ptr<BlockPCPhiPath>(New)));
+    Tmp.push_back(New);
+  }
+  // Original path takes the first branch
+  Current->BlockConstraints[I->B] = 0;
+
+  auto PCMap = BlockPCMap.find(I->B);
+  if (PCMap != BlockPCMap.end()) {
+    for (unsigned J = 0; J < Ops.size(); ++J) {
+      auto P = PCMap->second.find(J);
+      if (P != PCMap->second.end())
+        Tmp[J]->PCs.push_back(P->second);
+    }
+  }
+  // Continue recursively
+  for (unsigned J = 0; J < Ops.size(); ++J)
+    getBlockPCPhiPaths(Ops[J], Tmp[J], Paths, CachedPhis);
+}
+
 // Return an expression which must be proven valid for the candidate to apply.
 CandidateExpr souper::GetCandidateExprForReplacement(
-    const std::vector<InstMapping> &PCs, InstMapping Mapping) {
+    const BlockPCs &BPCs, const std::vector<InstMapping> &PCs,
+    InstMapping Mapping) {
+
   CandidateExpr CE;
   ExprBuilder EB(CE.Arrays, CE.ArrayVars);
 
@@ -762,19 +886,24 @@ CandidateExpr souper::GetCandidateExprForReplacement(
     Ante = AndExpr::create(Ante, EB.getInstMapping(PC));
   }
   Ante = AndExpr::create(Ante, EB.getUBInstCondition());
+  if (BPCs.size()) {
+    EB.setBlockPCMap(BPCs);
+    Ante = AndExpr::create(Ante, EB.getBlockPCs());
+  }
 
   CE.E = Expr::createImplies(Ante, Cons);
 
   return CE;
 }
 
-std::string souper::BuildQuery(const std::vector<InstMapping> &PCs,
+std::string souper::BuildQuery(const BlockPCs &BPCs,
+                               const std::vector<InstMapping> &PCs,
                                InstMapping Mapping,
                                std::vector<Inst *> *ModelVars) {
   std::string SMTStr;
   llvm::raw_string_ostream SMTSS(SMTStr);
   ConstraintManager Manager;
-  CandidateExpr CE = GetCandidateExprForReplacement(PCs, Mapping);
+  CandidateExpr CE = GetCandidateExprForReplacement(BPCs, PCs, Mapping);
   Query KQuery(Manager, CE.E);
   ExprSMTLIBLetPrinter Printer;
   Printer.setOutput(SMTSS);

--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -172,6 +172,28 @@ void ReplacementContext::clear() {
   NameToBlock.clear();
 }
 
+void ReplacementContext::printPCs(const std::vector<InstMapping> &PCs,
+                                  llvm::raw_ostream &Out, bool printNames) {
+  for (const auto &PC : PCs) {
+    std::string SRef = printInst(PC.LHS, Out, printNames);
+    std::string RRef = printInst(PC.RHS, Out, printNames);
+    Out << "pc " << SRef << " " << RRef << '\n';
+  }
+}
+
+void ReplacementContext::printBlockPCs(const BlockPCs &BPCs,
+                                       llvm::raw_ostream &Out,
+                                       bool printNames) {
+  for (auto &BPC : BPCs) {
+    assert(BPC.B && "NULL Block pointer!");
+    std::string BlockName = printBlock(BPC.B, Out);
+    std::string SRef = printInst(BPC.PC.LHS, Out, printNames);
+    std::string RRef = printInst(BPC.PC.RHS, Out, printNames);
+    Out << "blockpc %" << BlockName << " " << BPC.PredIdx << " ";
+    Out << SRef << " " << RRef << '\n';
+  }
+}
+
 bool ReplacementContext::empty() {
   return NameToInst.empty() && NameToBlock.empty();
 }
@@ -479,53 +501,49 @@ bool Inst::isCommutative(Inst::Kind K) {
 }
 
 void souper::PrintReplacement(llvm::raw_ostream &Out,
+                              const BlockPCs &BPCs,
                               const std::vector<InstMapping> &PCs,
                               InstMapping Mapping, bool printNames) {
   assert(Mapping.LHS);
   assert(Mapping.RHS);
 
   ReplacementContext Context;
-  for (const auto &PC : PCs) {
-    std::string SRef = Context.printInst(PC.LHS, Out, printNames);
-    std::string RRef = Context.printInst(PC.RHS, Out, printNames);
-    Out << "pc " << SRef << " " << RRef << '\n';
-  }
-
+  Context.printPCs(PCs, Out, printNames);
+  Context.printBlockPCs(BPCs, Out, printNames);
   std::string SRef = Context.printInst(Mapping.LHS, Out, printNames);
   std::string RRef = Context.printInst(Mapping.RHS, Out, printNames);
   Out << "cand " << SRef << " " << RRef << '\n';
 }
 
-std::string souper::GetReplacementString(const std::vector<InstMapping> &PCs,
+std::string souper::GetReplacementString(const BlockPCs &BPCs,
+                                         const std::vector<InstMapping> &PCs,
                                          InstMapping Mapping, bool printNames) {
   std::string Str;
   llvm::raw_string_ostream SS(Str);
-  PrintReplacement(SS, PCs, Mapping, printNames);
+  PrintReplacement(SS, BPCs, PCs, Mapping, printNames);
   return SS.str();
 }
 
 void souper::PrintReplacementLHS(llvm::raw_ostream &Out,
+                                 const BlockPCs &BPCs,
                                  const std::vector<InstMapping> &PCs,
                                  Inst *LHS, ReplacementContext &Context,
                                  bool printNames) {
   assert(LHS);
   assert(Context.empty());
 
-  for (const auto &PC : PCs) {
-    std::string SRef = Context.printInst(PC.LHS, Out, printNames);
-    std::string RRef = Context.printInst(PC.RHS, Out, printNames);
-    Out << "pc " << SRef << " " << RRef << '\n';
-  }
-
+  Context.printPCs(PCs, Out, printNames);
+  Context.printBlockPCs(BPCs, Out, printNames);
   std::string SRef = Context.printInst(LHS, Out, printNames);
   Out << "infer " << SRef << '\n';
 }
 
-std::string souper::GetReplacementLHSString(const std::vector<InstMapping> &PCs,
+std::string souper::GetReplacementLHSString(const BlockPCs &BPCs,
+    const std::vector<InstMapping> &PCs,
     Inst *LHS, ReplacementContext &Context, bool printNames) {
   std::string Str;
   llvm::raw_string_ostream SS(Str);
-  PrintReplacementLHS(SS, PCs, LHS, Context);
+  PrintReplacementLHS(SS, BPCs, PCs, LHS, Context);
   return SS.str();
 }
 

--- a/lib/Pass/Pass.cpp
+++ b/lib/Pass/Pass.cpp
@@ -169,7 +169,7 @@ public:
           I->print(errs());
           errs() << "\n; Generating replacement:\n";
           ReplacementContext Context;
-          PrintReplacementLHS(errs(), R.PCs, R.Mapping.LHS, Context);
+          PrintReplacementLHS(errs(), R.BPCs, R.PCs, R.Mapping.LHS, Context);
         }
         AddToCandidateMap(CandMap, R);
       }
@@ -189,11 +189,13 @@ public:
         I->getDebugLoc().print(I->getContext(), Loc);
         std::string HField = "sprofile " + Loc.str();
         ReplacementContext Context;
-        KV->hIncrBy(GetReplacementLHSString(Cand.PCs, Cand.Mapping.LHS, Context),
+        KV->hIncrBy(GetReplacementLHSString(Cand.BPCs, Cand.PCs,
+                                            Cand.Mapping.LHS, Context),
                     HField, 1);
       }
       if (std::error_code EC =
-          S->infer(Cand.PCs, Cand.Mapping.LHS, Cand.Mapping.RHS, IC)) {
+          S->infer(Cand.BPCs, Cand.PCs, Cand.Mapping.LHS,
+                   Cand.Mapping.RHS, IC)) {
         if (EC == std::errc::timed_out)
           continue;
         if (IgnoreSolverErrors) {
@@ -217,7 +219,7 @@ public:
         errs() << "\"\n; with \"";
         CI->print(errs());
         errs() << "\" in:\n";
-        PrintReplacement(errs(), Cand.PCs, Cand.Mapping);
+        PrintReplacement(errs(), Cand.BPCs, Cand.PCs, Cand.Mapping);
       }
       if (ReplaceCount >= FirstReplace && ReplaceCount <= LastReplace) {
         BasicBlock::iterator BI = I;
@@ -228,8 +230,9 @@ public:
           I->getDebugLoc().print(I->getContext(), Loc);
           ReplacementContext Context;
           dynamicProfile (F.getContext(), F.getParent(),
-                          GetReplacementLHSString(Cand.PCs, Cand.Mapping.LHS,
-                                                  Context), Loc.str(), BI);
+                          GetReplacementLHSString(Cand.BPCs, Cand.PCs,
+                                                  Cand.Mapping.LHS, Context),
+                          Loc.str(), BI);
         }
         changed = true;
       } else {

--- a/lib/Tool/CandidateMapUtils.cpp
+++ b/lib/Tool/CandidateMapUtils.cpp
@@ -56,7 +56,8 @@ bool SolveCandidateMap(llvm::raw_ostream &OS, CandidateMap &M,
     for (int I=0; I < M.size(); ++I) {
       auto &Cand = M[I];
       ReplacementContext Context;
-      auto S = GetReplacementLHSString(Cand.PCs, Cand.Mapping.LHS, Context);
+      auto S = GetReplacementLHSString(Cand.BPCs, Cand.PCs,
+                                       Cand.Mapping.LHS, Context);
       if (Index.find(S) == Index.end()) {
         Index[S] = I;
         Profile.push_back(1);
@@ -78,13 +79,13 @@ bool SolveCandidateMap(llvm::raw_ostream &OS, CandidateMap &M,
         I->getDebugLoc().print(I->getContext(), Loc);
         std::string HField = "sprofile " + Loc.str();
         ReplacementContext Context;
-        KVForStaticProfile->hIncrBy(GetReplacementLHSString(Cand.PCs,
-            Cand.Mapping.LHS, Context), HField, 1);
+        KVForStaticProfile->hIncrBy(GetReplacementLHSString(Cand.BPCs,
+            Cand.PCs, Cand.Mapping.LHS, Context), HField, 1);
       }
 
       Inst *RHS;
       if (std::error_code EC =
-              S->infer(Cand.PCs, Cand.Mapping.LHS, RHS, IC)) {
+              S->infer(Cand.BPCs, Cand.PCs, Cand.Mapping.LHS, RHS, IC)) {
         llvm::errs() << "Unable to query solver: " << EC.message() << '\n';
         return false;
       }
@@ -122,7 +123,7 @@ bool CheckCandidateMap(llvm::Module &Mod, CandidateMap &M, Solver *S,
   for (auto &Cand : M) {
     Inst *RHS;
     if (std::error_code EC =
-            S->infer(Cand.PCs, Cand.Mapping.LHS, RHS, IC)) {
+            S->infer(Cand.BPCs, Cand.PCs, Cand.Mapping.LHS, RHS, IC)) {
       llvm::errs() << "Unable to query solver: " << EC.message() << '\n';
       return false;
     }

--- a/test/Extractor/blockpc1.ll
+++ b/test/Extractor/blockpc1.ll
@@ -1,0 +1,45 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+; Function Attrs: nounwind uwtable
+define i32 @foo() #0 {
+entry:
+  br label %for.cond
+
+for.cond:                                         ; preds = %for.body, %entry
+  %i.0 = phi i32 [ undef, %entry ], [ %inc1, %for.body ]
+  %len.0 = phi i32 [ undef, %entry ], [ %inc, %for.body ]
+  %tobool = icmp eq i32 %i.0, 0
+  br i1 %tobool, label %for.end, label %for.body
+
+for.body:                                         ; preds = %for.cond
+  %inc = add i32 %len.0, 1
+  %inc1 = add i32 %i.0, 1
+  br label %for.cond
+
+for.end:                                          ; preds = %for.cond
+  %tobool2 = icmp eq i32 %len.0, 0
+  br i1 %tobool2, label %if.end, label %if.then
+
+if.then:                                          ; preds = %for.end
+  %inc3 = add i32 %len.0, 1
+  br label %if.end
+
+if.end:                                           ; preds = %for.end, %if.then
+  %len.1 = phi i32 [ %inc3, %if.then ], [ %len.0, %for.end ]
+  %tobool4 = icmp eq i32 %len.1, 0
+  br i1 %tobool4, label %if.end6, label %if.then5
+
+if.then5:                                         ; preds = %if.end
+  br label %return
+
+if.end6:                                          ; preds = %if.end
+  br label %return
+
+return:                                           ; preds = %if.end6, %if.then5
+  %retval.0 = phi i32 [ 1, %if.then5 ], [ 0, %if.end6 ]
+  ret i32 %retval.0
+}
+

--- a/test/Extractor/blockpc2.ll
+++ b/test/Extractor/blockpc2.ll
@@ -1,0 +1,39 @@
+
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+define zeroext i1 @c_ispunct(i32 %a, i32 %b, i32 %c) {
+entry:
+  switch i32 %a, label %default [
+    i32 0, label %bb2
+    i32 1, label %bb3
+  ]
+
+default:                                    ; preds = %entry
+  %cmp1 = icmp eq i32 %c, 0
+  br i1 %cmp1, label %bb1, label %return
+
+bb1:                                        ; preds = %default
+  %inc = add i32 %a, 1
+  br label %bb4
+
+bb2:                                        ; preds = %entry
+  br label %bb4
+
+bb3:                                        ; preds = %entry
+  %cmp2 = icmp eq i32 1, %a, !expected !1
+  br i1 %cmp2, label %bb2, label %bb4
+
+bb4:                                        ; preds = %bb1, %bb2, %bb3
+  %phi1 = phi i32 [ %b, %bb3 ], [ %b, %bb2 ], [ %inc, %bb1 ]
+  %cmp4 = icmp ult i32 %phi1, %a
+  br label %return
+
+return:                                     ; preds = %bb4, %default
+  %retval.0 = phi i1 [ %cmp4, %bb4 ], [ %cmp1, %default ]
+  ret i1 %retval.0
+}
+
+!1 = metadata !{ i1 1 }

--- a/test/Extractor/pc1.ll
+++ b/test/Extractor/pc1.ll
@@ -1,0 +1,39 @@
+
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+; Function Attrs: nounwind uwtable
+define void @fn1() #0 {
+entry:
+  br i1 true, label %if.then, label %if.end12
+
+if.then:                                          ; preds = %entry
+  br i1 true, label %if.then2, label %if.end
+
+if.then2:                                         ; preds = %if.then
+  %0 = add i32 0, 0
+  br label %if.end
+
+if.end:                                           ; preds = %if.then2, %if.then
+  %tt.0 = phi i32 [ %0, %if.then2 ], [ undef, %if.then ]
+  br i1 true, label %if.then5, label %if.end7
+
+if.then5:                                         ; preds = %if.end
+  %1 = add i32 0, 0
+  br label %if.end7
+
+if.end7:                                          ; preds = %if.then5, %if.end
+  %tt.1 = phi i32 [ %1, %if.then5 ], [ %tt.0, %if.end ]
+  %tobool8 = icmp eq i32 %tt.1, 0, !expected !1
+  br i1 %tobool8, label %if.end12, label %if.then9
+
+if.then9:                                         ; preds = %if.end7
+  br label %if.end12
+
+if.end12:                                         ; preds = %if.end7, %if.then9, %entry
+  ret void
+}
+
+!1 = metadata !{ i1 1 }

--- a/test/Extractor/pc2.ll
+++ b/test/Extractor/pc2.ll
@@ -1,0 +1,52 @@
+
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+; Function Attrs: nounwind
+define i32 @fn1() #0 {
+entry:
+  %0 = add i32 4, 0
+  %tobool = icmp eq i32 %0, 0, !expected !0
+  br i1 %tobool, label %if.end13, label %for.cond.preheader
+
+for.cond.preheader:                               ; preds = %entry
+  %1 = add i32 1, 0
+  %tobool119 = icmp eq i32 1, 0, !expected !0
+  br i1 %tobool119, label %if.end.lr.ph, label %for.end.loopexit
+
+if.end.lr.ph:                                     ; preds = %for.cond.preheader
+  br label %if.end
+
+if.end:                                           ; preds = %if.end.lr.ph, %cleanup
+  %d.020 = phi i64 [ undef, %if.end.lr.ph ], [ %d.1, %cleanup ]
+  %tobool3 = icmp eq i64 %d.020, 0
+  %d.1 = select i1 %tobool3, i64 0, i64 1
+  %tobool6 = icmp eq i1 %tobool3, 0
+  br i1 %tobool6, label %cleanup, label %if.then7
+
+if.then7:                                         ; preds = %if.end
+  br label %for.end
+
+cleanup:                                          ; preds = %if.end
+  %tobool1 = icmp eq i32 1, 0, !expected !0
+  br i1 %tobool1, label %if.end, label %for.cond.for.end.loopexit_crit_edge
+
+for.cond.for.end.loopexit_crit_edge:              ; preds = %cleanup
+  br label %for.end.loopexit
+
+for.end.loopexit:                                 ; preds = %for.cond.for.end.loopexit_crit_edge, %for.cond.preheader
+  %d.0.lcssa = phi i64 [ %d.1, %for.cond.for.end.loopexit_crit_edge ], [ undef, %for.cond.preheader ]
+  br label %for.end
+
+for.end:                                          ; preds = %for.end.loopexit, %if.then7
+  %d.2.ph = phi i64 [ %d.1, %if.then7 ], [ %d.0.lcssa, %for.end.loopexit ]
+  %tobool10 = icmp eq i64 %d.2.ph, 0
+  br label %if.end13
+
+if.end13:                                         ; preds = %for.end, %entry, %if.then11
+  ret i32 undef
+}
+
+!0 = metadata !{ i1 0 }

--- a/test/Solver/blockpc_ifelse1.ll
+++ b/test/Solver/blockpc_ifelse1.ll
@@ -1,0 +1,26 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+define i32 @foo(i32 %x) {
+entry:
+%cmp1 = icmp eq i32 %x, 0
+br i1 %cmp1, label %cond1, label %cond2
+
+cond1:
+%t10 = add nsw i32 10, %x
+br label %phi
+
+cond2:
+br label %phi
+
+phi:
+%r = phi i32 [10, %cond2], [%t10, %cond1]
+%cmp = icmp eq i32 %r, 10, !expected !1
+%conv = zext i1 %cmp to i32
+ret i32 %conv
+}
+
+!1 = metadata !{ i1 1 }
+

--- a/test/Solver/blockpc_ifelse2.ll
+++ b/test/Solver/blockpc_ifelse2.ll
@@ -1,0 +1,40 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+define i32 @foo(i32 %x) {
+entry:
+%cmp1 = icmp eq i32 %x, 0
+br i1 %cmp1, label %cond1, label %cond2
+
+cond1:                   ; preds = %entry
+%x10 = add nsw i32 10, %x
+br label %phi1
+
+cond2:                   ; preds = %entry
+br label %phi1
+
+phi1:                    ; preds = %cond1, %cond2
+%r = phi i32 [10, %cond2], [%x10, %cond1]
+%cmp2 = icmp eq i32 %r, 10, !expected !1
+br i1 %cmp2, label %cond3, label %cond4
+
+cond3:                   ; preds = %phi1
+%cmp10 = zext i1 %cmp2 to i32
+%t1 = add nsw i32 %cmp10, 0
+br label %phi2
+
+cond4:                   ; preds = %phi1
+%t2 = add nsw i32 0, 1
+br label %phi2
+
+phi2:                    ; preds = %cond3, %cond4
+%t3 = phi i32 [%t1, %cond3], [%t2, %cond4]
+%cmp4 = icmp eq i32 %t3, 1, !expected !1
+%conv = zext i1 %cmp4 to i32
+ret i32 %conv
+}
+
+!1 = metadata !{ i1 1 }
+

--- a/test/Solver/blockpc_switch.ll
+++ b/test/Solver/blockpc_switch.ll
@@ -1,0 +1,81 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+define i32 @foo(i32 %a) #0 {
+entry:
+  switch i32 %a, label %sw.default [
+    i32 0, label %sw.bb
+    i32 1, label %sw.bb1
+    i32 2, label %sw.bb3
+    i32 3, label %sw.bb5
+    i32 4, label %sw.bb7
+    i32 5, label %sw.bb9
+    i32 6, label %sw.bb11
+    i32 7, label %sw.bb13
+    i32 8, label %sw.bb15
+    i32 9, label %sw.bb17
+    i32 10, label %sw.bb19
+  ]
+
+sw.bb:                                            ; preds = %entry
+  %add = add nsw i32 10, %a
+  br label %sw.epilog
+
+sw.bb1:                                           ; preds = %entry
+  %add2 = add nsw i32 9, %a
+  br label %sw.epilog
+
+sw.bb3:                                           ; preds = %entry
+  %add4 = add nsw i32 8, %a
+  br label %sw.epilog
+
+sw.bb5:                                           ; preds = %entry
+  %add6 = add nsw i32 7, %a
+  br label %sw.epilog
+
+sw.bb7:                                           ; preds = %entry
+  %add8 = add nsw i32 6, %a
+  br label %sw.epilog
+
+sw.bb9:                                           ; preds = %entry
+  %add10 = add nsw i32 5, %a
+  br label %sw.epilog
+
+sw.bb11:                                          ; preds = %entry
+  %add12 = add nsw i32 4, %a
+  br label %sw.epilog
+
+sw.bb13:                                          ; preds = %entry
+  %add14 = add nsw i32 3, %a
+  br label %sw.epilog
+
+sw.bb15:                                          ; preds = %entry
+  %add16 = add nsw i32 2, %a
+  br label %sw.epilog
+
+sw.bb17:                                          ; preds = %entry
+  %add18 = add nsw i32 1, %a
+  br label %sw.epilog
+
+sw.bb19:                                          ; preds = %entry
+  %add20 = add nsw i32 0, %a
+  br label %sw.epilog
+
+sw.default:                                       ; preds = %entry
+  br label %sw.epilog
+
+sw.epilog:                                        ; preds = %sw.default, %sw.bb19, %sw.bb17, %sw.bb15, %sw.bb13, %sw.bb11, %sw.bb9, %sw.bb7, %sw.bb5, %sw.bb3, %sw.bb1, %sw.bb
+  %c.0 = phi i32 [ 10, %sw.default ], [ %add20, %sw.bb19 ], [ %add18, %sw.bb17 ], [ %add16, %sw.bb15 ], [ %add14, %sw.bb13 ], [ %add12, %sw.bb11 ], [ %add10, %sw.bb9 ], [ %add8, %sw.bb7 ], [ %add6, %sw.bb5 ], [ %add4, %sw.bb3 ], [ %add2, %sw.bb1 ], [ %add, %sw.bb ]
+  %cmp = icmp eq i32 %c.0, 10, !expected !1
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.ident = !{!0}
+
+!0 = metadata !{metadata !"clang version 3.6.0 (219188)"}
+!1 = metadata !{ i1 1 }

--- a/test/Tool/blockpc-invalid-1.opt
+++ b/test/Tool/blockpc-invalid-1.opt
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %souper-check %solver -print-counterexample=false %s > %t 2>&1
+; RUN: FileCheck %s < %t
+
+; CHECK: Invalid
+%0 = block 3
+%1:i32 = var
+%2:i1 = ne 0:i32, %1
+%3:i1 = ne 1:i32, %1
+blockpc %0 1 %1 0:i32
+blockpc %0 2 %1 0:i32
+%4:i32 = addnsw 9:i32, %1
+%5:i32 = addnsw 10:i32, %1
+%6:i32 = phi %0, 10:i32, %4, %5
+%7:i1 = eq 10:i32, %6
+cand %7 1:i1

--- a/test/Tool/blockpc-invalid-2.opt
+++ b/test/Tool/blockpc-invalid-2.opt
@@ -1,0 +1,20 @@
+; REQUIRES: solver
+
+; RUN: %souper-check %solver -print-counterexample=false %s > %t 2>&1
+; RUN: FileCheck %s < %t
+
+; CHECK: Invalid
+%0 = block 2
+%1:i32 = var
+%2:i1 = eq 0:i32, %1
+%3 = block 2
+%4:i32 = addnsw 10:i32, %1
+%5:i32 = phi %0, 10:i32, %4
+%6:i1 = eq 10:i32, %5
+blockpc %3 1 %6 0:i1
+%7:i32 = zext %6
+%8:i32 = addnsw 0:i32, %7
+%9:i32 = addnsw 0:i32, 1:i32
+%10:i32 = phi %3, %8, %9
+%11:i1 = eq 1:i32, %10
+cand %11 1:i1

--- a/test/Tool/blockpc-lgtm-1.opt
+++ b/test/Tool/blockpc-lgtm-1.opt
@@ -1,0 +1,19 @@
+; REQUIRES: solver
+
+; RUN: %souper-check %solver -print-counterexample=false %s > %t 2>&1
+; RUN: FileCheck %s < %t
+
+; CHECK: LGTM
+%0 = block 3
+%1:i32 = var
+%2:i1 = ne 0:i32, %1
+%3:i1 = ne 1:i32, %1
+%4:i1 = and %2, %3
+blockpc %0 0 %4 1:i1
+blockpc %0 1 %1 1:i32
+blockpc %0 2 %1 0:i32
+%5:i32 = addnsw 9:i32, %1
+%6:i32 = addnsw 10:i32, %1
+%7:i32 = phi %0, 10:i32, %5, %6
+%8:i1 = eq 10:i32, %7
+cand %8 1:i1

--- a/test/Tool/blockpc-lgtm-2.opt
+++ b/test/Tool/blockpc-lgtm-2.opt
@@ -1,0 +1,23 @@
+; REQUIRES: solver
+
+; RUN: %souper-check %solver -print-counterexample=false %s > %t 2>&1
+; RUN: FileCheck %s < %t
+
+; CHECK: LGTM
+%0 = block 2
+%1:i32 = var
+%2:i1 = eq 0:i32, %1
+blockpc %0 0 %2 0:i1
+blockpc %0 1 %2 1:i1
+%3 = block 2
+%4:i32 = addnsw 10:i32, %1
+%5:i32 = phi %0, 10:i32, %4
+%6:i1 = eq 10:i32, %5
+blockpc %3 0 %6 1:i1
+blockpc %3 1 %6 0:i1
+%7:i32 = zext %6
+%8:i32 = addnsw 0:i32, %7
+%9:i32 = addnsw 0:i32, 1:i32
+%10:i32 = phi %3, %8, %9
+%11:i1 = eq 1:i32, %10
+cand %11 1:i1

--- a/test/Tool/blockpc-lgtm-3.opt
+++ b/test/Tool/blockpc-lgtm-3.opt
@@ -1,0 +1,23 @@
+; REQUIRES: solver
+
+; RUN: %souper-check %solver -print-counterexample=false %s > %t 2>&1
+; RUN: FileCheck %s < %t
+
+; CHECK: LGTM
+%0 = block 2
+%1:i32 = var
+%2:i1 = eq 0:i32, %1
+blockpc %0 1 %2 1:i1
+%3 = block 2
+%4:i32 = addnsw 10:i32, %1
+%5:i32 = phi %0, 10:i32, %4
+%6:i1 = eq 10:i32, %5
+blockpc %3 1 %6 0:i1
+%7:i32 = zext %6
+%8:i32 = addnsw 0:i32, %7
+blockpc %3 0 %6 1:i1
+%9:i32 = addnsw 0:i32, 1:i32
+blockpc %0 0 %2 0:i1
+%10:i32 = phi %3, %8, %9
+%11:i1 = eq 1:i32, %10
+cand %11 1:i1

--- a/test/Tool/blockpc-lgtm-4.opt
+++ b/test/Tool/blockpc-lgtm-4.opt
@@ -1,0 +1,19 @@
+; REQUIRES: solver
+
+; RUN: %souper-check %solver -print-counterexample=false %s > %t 2>&1
+; RUN: FileCheck %s < %t
+
+; CHECK: LGTM
+%0 = block 3
+%1:i32 = var
+%2:i1 = ne 0:i32, %1
+%3:i1 = ne 1:i32, %1
+%4:i1 = and %2, %3
+blockpc %0 1 %1 1:i32
+%5:i32 = addnsw 9:i32, %1
+blockpc %0 2 %1 0:i32
+%6:i32 = addnsw 10:i32, %1
+blockpc %0 0 %4 1:i1
+%7:i32 = phi %0, 10:i32, %5, %6
+%8:i1 = eq 10:i32, %7
+cand %8 1:i1

--- a/tools/souper-check.cpp
+++ b/tools/souper-check.cpp
@@ -70,18 +70,19 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
   }
 
   if (InferRHS) {
-    if (std::error_code EC = S->infer(Rep.PCs, Rep.Mapping.LHS, Rep.Mapping.RHS,
-                                      IC)) {
+    if (std::error_code EC = S->infer(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
+                                      Rep.Mapping.RHS, IC)) {
       llvm::errs() << EC.message() << '\n';
       return 1;
     }
     if (Rep.Mapping.RHS) {
       llvm::outs() << "; RHS inferred successfully\n";
       if (PrintRepl) {
-        PrintReplacement(llvm::outs(), Rep.PCs, Rep.Mapping);
+        PrintReplacement(llvm::outs(), Rep.BPCs, Rep.PCs, Rep.Mapping);
       } else if (PrintReplSplit) {
         ReplacementContext Context;
-        PrintReplacementLHS(llvm::outs(), Rep.PCs, Rep.Mapping.LHS, Context);
+        PrintReplacementLHS(llvm::outs(), Rep.BPCs, Rep.PCs,
+                            Rep.Mapping.LHS, Context);
         PrintReplacementRHS(llvm::outs(), Rep.Mapping.RHS, Context);
       } else {
         PrintReplacementRHS(llvm::outs(), Rep.Mapping.RHS, Context);
@@ -90,13 +91,15 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
       llvm::outs() << "; Failed to infer RHS\n";
       if (PrintRepl || PrintReplSplit) {
         ReplacementContext Context;
-        PrintReplacementLHS(llvm::outs(), Rep.PCs, Rep.Mapping.LHS, Context);
+        PrintReplacementLHS(llvm::outs(), Rep.BPCs, Rep.PCs,
+                            Rep.Mapping.LHS, Context);
       }
     }
   } else {
     bool Valid;
     std::vector<std::pair<Inst *, APInt>> Models;
-    if (std::error_code EC = S->isValid(Rep.PCs, Rep.Mapping, Valid, &Models)) {
+    if (std::error_code EC = S->isValid(Rep.BPCs, Rep.PCs,
+                                        Rep.Mapping, Valid, &Models)) {
       llvm::errs() << EC.message() << '\n';
       return 1;
     }
@@ -104,10 +107,11 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
     if (Valid) {
       llvm::outs() << "; LGTM\n";
       if (PrintRepl)
-        PrintReplacement(llvm::outs(), Rep.PCs, Rep.Mapping);
+        PrintReplacement(llvm::outs(), Rep.BPCs, Rep.PCs, Rep.Mapping);
       if (PrintReplSplit) {
         ReplacementContext Context;
-        PrintReplacementLHS(llvm::outs(), Rep.PCs, Rep.Mapping.LHS, Context);
+        PrintReplacementLHS(llvm::outs(), Rep.BPCs, Rep.PCs,
+                            Rep.Mapping.LHS, Context);
         PrintReplacementRHS(llvm::outs(), Rep.Mapping.RHS, Context);
       }
     } else {

--- a/tools/souperweb-backend.cpp
+++ b/tools/souperweb-backend.cpp
@@ -59,7 +59,8 @@ void SolveInst(std::unique_ptr<MemoryBuffer> MB, Solver *S) {
 
   bool Valid;
   std::vector<std::pair<Inst *, APInt>> Models;
-  if (std::error_code EC = S->isValid(Rep.PCs, Rep.Mapping, Valid, &Models)) {
+  if (std::error_code EC = S->isValid(Rep.BPCs, Rep.PCs,
+                                      Rep.Mapping, Valid, &Models)) {
     llvm::errs() << EC.message() << '\n';
     return;
   }

--- a/unittests/Extractor/ExtractorTests.cpp
+++ b/unittests/Extractor/ExtractorTests.cpp
@@ -62,7 +62,7 @@ struct ExtractorTest : testing::Test {
         for (auto I : Guesses) {
           R.Mapping.RHS = I;
           std::unique_ptr<CandidateExpr> CE(
-              new CandidateExpr(GetCandidateExprForReplacement(R.PCs,
+              new CandidateExpr(GetCandidateExprForReplacement(R.BPCs, R.PCs,
                                                                R.Mapping)));
           CandExprs.emplace_back(std::move(CE));
         }


### PR DESCRIPTION
This patch addresses issue #81 by implementing blockpc based on Peter's
suggestion. blockpc has the same semantics as pc, except that pc only applies
when the given predecessor of the given block is chosen.

blockpc(s) are collected in a way similar to what we currently do for pc(s),
and are encoded with a similar technique for encoding UB constraints.

The parser is also updated to parse blockpc(s).

I am sorry the path is a bit big...
