### PR TITLE
Invoking PrintReplacementLHS for dumping all replacements

### DIFF
--- a/lib/Pass/Pass.cpp
+++ b/lib/Pass/Pass.cpp
@@ -161,7 +161,7 @@ public:
           errs() << "\n; For LLVM instruction:\n;";
           I->print(errs());
           errs() << "\n; Generating replacement:\n";
-          PrintReplacement(errs(), R.PCs, R.Mapping);
+          PrintReplacementLHS(errs(), R.PCs, R.Mapping.LHS);
         }
         AddToCandidateMap(CandMap, R);
       }

--- a/test/Pass/dump-all-replacements.ll
+++ b/test/Pass/dump-all-replacements.ll
@@ -1,0 +1,14 @@
+; REQUIRES: solver
+
+; RUN: opt -load %pass -souper %solver -S -o - %s -souper-debug -souper-debug-level=2 > %t 2>&1
+; RUN: FileCheck %s < %t
+
+; Check that the souper pass dumps all replacements.
+
+; CHECK: Listing all replacements for foo
+; CHECK: 0:i1 = eq 1:i32, 1:i32
+define void @foo() {
+entry:
+  %t = icmp eq i32 1, 1
+  ret void
+}


### PR DESCRIPTION
Because RHS is NULL after we switched to infer mode,
we need to use PrintReplacementLHS rather than PrintReplacement.
Otherwise, souper pass would crash by passing -souper-debug-level=2.
