### PR TITLE
Fix to Issue #84

### DIFF
--- a/test/Solver/div-by-zero1.ll
+++ b/test/Solver/div-by-zero1.ll
@@ -1,0 +1,83 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+define void @fn1() {
+entry:
+  %d1 = sdiv i32 1, 0 
+  %b1 = icmp eq i32 %d1, 0, !expected !1
+  br i1 %b1, label %cond.true, label %cond.false
+
+  %d2 = sdiv i32 0, 0 
+  %b2 = icmp eq i32 %d2, 0, !expected !1
+  br i1 %b2, label %cond.true, label %cond.false
+
+  %d3 = sdiv i32 0, undef
+  %b3 = icmp eq i32 %d3, 0, !expected !1
+  br i1 %b3, label %cond.true, label %cond.false
+
+  %d4 = sdiv i32 undef, undef
+  %b4 = icmp eq i32 %d4, 0, !expected !1
+  br i1 %b4, label %cond.true, label %cond.false
+
+  %d5 = udiv i32 1, 0 
+  %b5 = icmp eq i32 %d5, 0, !expected !1
+  br i1 %b5, label %cond.true, label %cond.false
+
+  %d6 = udiv i32 0, 0 
+  %b6 = icmp eq i32 %d6, 0, !expected !1
+  br i1 %b6, label %cond.true, label %cond.false
+
+  %d7 = udiv i32 0, undef
+  %b7 = icmp eq i32 %d7, 0, !expected !1
+  br i1 %b7, label %cond.true, label %cond.false
+
+  %d8 = udiv i32 0, undef
+  %b8 = icmp eq i32 %d8, 0, !expected !1
+  br i1 %b8, label %cond.true, label %cond.false
+
+  %d9 = urem i32 1, 0 
+  %b9 = icmp eq i32 %d9, 0, !expected !1
+  br i1 %b9, label %cond.true, label %cond.false
+
+  %d10 = urem i32 0, 0 
+  %b10 = icmp eq i32 %d10, 0, !expected !1
+  br i1 %b10, label %cond.true, label %cond.false
+
+  %d11 = urem i32 0, undef
+  %b11 = icmp eq i32 %d11, 0, !expected !1
+  br i1 %b11, label %cond.true, label %cond.false
+
+  %d12 = urem i32 0, undef
+  %b12 = icmp eq i32 %d12, 0, !expected !1
+  br i1 %b12, label %cond.true, label %cond.false
+
+  %d13 = srem i32 1, 0 
+  %b13 = icmp eq i32 %d13, 0, !expected !1
+  br i1 %b13, label %cond.true, label %cond.false
+
+  %d14 = srem i32 0, 0 
+  %b14 = icmp eq i32 %d14, 0, !expected !1
+  br i1 %b14, label %cond.true, label %cond.false
+
+  %d15 = srem i32 0, undef
+  %b15 = icmp eq i32 %d15, 0, !expected !1
+  br i1 %b15, label %cond.true, label %cond.false
+
+  %d16 = srem i32 0, undef
+  %b16 = icmp eq i32 %d16, 0, !expected !1
+  br i1 %b16, label %cond.true, label %cond.false
+
+cond.true:
+  br label %return
+
+cond.false:
+  br label %return
+
+return:
+  ret void
+}
+
+!1 = metadata !{ i1 1 }
+

--- a/test/Solver/div-by-zero2.ll
+++ b/test/Solver/div-by-zero2.ll
@@ -1,0 +1,107 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+define void @fn1() {
+entry:
+  %s11 = zext i8 undef to i16
+  %s12 = sext i16 %s11 to i32
+  %d1 = sdiv i32 1, %s12
+  %b1 = icmp eq i32 %d1, 0, !expected !1
+  br i1 %b1, label %cond.true, label %cond.false
+
+  %s21 = sext i8 undef to i16
+  %s22 = zext i16 %s21 to i32
+  %d2 = sdiv i32 0, %s22
+  %b2 = icmp eq i32 %d2, 0, !expected !1
+  br i1 %b2, label %cond.true, label %cond.false
+
+  %s31 = sext i8 0 to i16
+  %s32 = zext i16 %s31 to i32
+  %d3 = sdiv i32 0, %s32
+  %b3 = icmp eq i32 %d3, 0, !expected !1
+  br i1 %b3, label %cond.true, label %cond.false
+
+  %s41 = zext i8 0 to i16
+  %s42 = sext i16 %s41 to i32
+  %d4 = sdiv i32 undef, %s42
+  %b4 = icmp eq i32 %d4, 0, !expected !1
+  br i1 %b4, label %cond.true, label %cond.false
+
+  %s51 = zext i8 undef to i16
+  %s52 = zext i16 %s51 to i32
+  %d5 = udiv i32 1, %s52
+  %b5 = icmp eq i32 %d5, 0, !expected !1
+  br i1 %b5, label %cond.true, label %cond.false
+
+  %s61 = zext i8 0 to i16
+  %s62 = zext i16 %s61 to i32
+  %d6 = udiv i32 0, %s62
+  %b6 = icmp eq i32 %d6, 0, !expected !1
+  br i1 %b6, label %cond.true, label %cond.false
+
+  %s71 = zext i8 undef to i16
+  %s72 = zext i16 %s71 to i32
+  %d7 = udiv i32 0, %s72
+  %b7 = icmp eq i32 %d7, 0, !expected !1
+  br i1 %b7, label %cond.true, label %cond.false
+
+  %s81 = zext i8 0 to i16
+  %s82 = zext i16 %s81 to i32
+  %d8 = udiv i32 0, %s82
+  %b8 = icmp eq i32 %d8, 0, !expected !1
+  br i1 %b8, label %cond.true, label %cond.false
+
+  %ss1 = zext i1 0 to i8
+  %ss2 = zext i8 %ss1 to i16
+  %ss3 = sext i8 %ss1 to i16
+  %ss4 = zext i16 %ss2 to i32
+  %ss5 = sext i16 %ss2 to i32
+  %ss6 = sext i16 %ss2 to i32
+  %ss7 = zext i16 %ss2 to i32
+
+  %d9 = urem i32 1, 0 
+  %b9 = icmp eq i32 %d9, %ss4, !expected !1
+  br i1 %b9, label %cond.true, label %cond.false
+
+  %d10 = urem i32 0, 0 
+  %b10 = icmp eq i32 %d10, %ss5, !expected !1
+  br i1 %b10, label %cond.true, label %cond.false
+
+  %d11 = urem i32 0, undef
+  %b11 = icmp eq i32 %d11, %ss6, !expected !1
+  br i1 %b11, label %cond.true, label %cond.false
+
+  %d12 = urem i32 0, undef
+  %b12 = icmp eq i32 %d12, %ss7, !expected !1
+  br i1 %b12, label %cond.true, label %cond.false
+
+  %d13 = srem i32 1, 0 
+  %b13 = icmp eq i32 %d13, %ss7, !expected !1
+  br i1 %b13, label %cond.true, label %cond.false
+
+  %d14 = srem i32 0, 0 
+  %b14 = icmp eq i32 %d14, %ss6, !expected !1
+  br i1 %b14, label %cond.true, label %cond.false
+
+  %d15 = srem i32 0, undef
+  %b15 = icmp eq i32 %d15, %ss5, !expected !1
+  br i1 %b15, label %cond.true, label %cond.false
+
+  %d16 = srem i32 0, undef
+  %b16 = icmp eq i32 %d16, %ss4, !expected !1
+  br i1 %b16, label %cond.true, label %cond.false
+
+cond.true:
+  br label %return
+
+cond.false:
+  br label %return
+
+return:
+  ret void
+}
+
+!1 = metadata !{ i1 1 }
+

--- a/test/Solver/div-by-zero3.ll
+++ b/test/Solver/div-by-zero3.ll
@@ -1,0 +1,99 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+define void @fn1() {
+entry:
+  %s1 = add i32 0, 0
+  %d1 = sdiv i32 1, %s1
+  %b1 = icmp eq i32 %d1, 0, !expected !1
+  br i1 %b1, label %cond.true, label %cond.false
+
+  %s2 = sub i32 0, 0
+  %d2 = sdiv i32 1, %s2
+  %b2 = icmp eq i32 %d2, 0, !expected !1
+  br i1 %b2, label %cond.true, label %cond.false
+
+  %s3 = sub i32 10, 10
+  %d3 = sdiv i32 1, %s3 
+  %b3 = icmp eq i32 %d3, 0, !expected !1
+  br i1 %b3, label %cond.true, label %cond.false
+
+  %s4 = mul i32 0, 10
+  %d4 = sdiv i32 1, %s4
+  %b4 = icmp eq i32 %d4, 0, !expected !1
+  br i1 %b4, label %cond.true, label %cond.false
+
+  %s5 = mul i32 10, 0
+  %d5 = udiv i32 1, %s5
+  %b5 = icmp eq i32 %d5, 0, !expected !1
+  br i1 %b5, label %cond.true, label %cond.false
+
+  %s6 = mul i32 0, undef
+  %d6 = udiv i32 1, %s6
+  %b6 = icmp eq i32 %d6, 0, !expected !1
+  br i1 %b6, label %cond.true, label %cond.false
+
+  %s7 = sub i32 undef, 0
+  %d7 = udiv i32 1, %s7
+  %b7 = icmp eq i32 %d7, 0, !expected !1
+  br i1 %b7, label %cond.true, label %cond.false
+
+  %s8 = shl i32 0, 1
+  %d8 = udiv i32 1, %s8
+  %b8 = icmp eq i32 %d8, 0, !expected !1
+  br i1 %b8, label %cond.true, label %cond.false
+
+  %s9 = sub i32 undef, undef
+  %d9 = urem i32 1, %s9
+  %b9 = icmp eq i32 %d9, 0, !expected !1
+  br i1 %b9, label %cond.true, label %cond.false
+
+  %s10 = mul i32 undef, 0
+  %d10 = urem i32 1, %s10
+  %b10 = icmp eq i32 %d10, 0, !expected !1
+  br i1 %b10, label %cond.true, label %cond.false
+
+  %s11 = udiv i32 0, 1
+  %d11 = urem i32 1, %s11
+  %b11 = icmp eq i32 %d11, 0, !expected !1
+  br i1 %b11, label %cond.true, label %cond.false
+
+  %s12 = sdiv i32 undef, 1
+  %d12 = urem i32 1, %s12
+  %b12 = icmp eq i32 %d12, 0, !expected !1
+  br i1 %b12, label %cond.true, label %cond.false
+
+  %s13 = srem i32 undef, 1
+  %d13 = srem i32 1, %s13
+  %b13 = icmp eq i32 %d13, 0, !expected !1
+  br i1 %b13, label %cond.true, label %cond.false
+
+  %s14 = urem i32 0, 1
+  %d14 = srem i32 1, %s14
+  %b14 = icmp eq i32 %d14, 0, !expected !1
+  br i1 %b14, label %cond.true, label %cond.false
+
+  %s15 = lshr i32 0, 1
+  %d15 = srem i32 1, %s15
+  %b15 = icmp eq i32 %d15, 0, !expected !1
+  br i1 %b15, label %cond.true, label %cond.false
+
+  %s16 = shl i32 0, 1
+  %d16 = srem i32 1, %s16
+  %b16 = icmp eq i32 %d16, 0, !expected !1
+  br i1 %b16, label %cond.true, label %cond.false
+
+cond.true:
+  br label %return
+
+cond.false:
+  br label %return
+
+return:
+  ret void
+}
+
+!1 = metadata !{ i1 1 }
+


### PR DESCRIPTION
We can't pass a constant zero as a divisor when building KLEE expressions,
because KLEE invokes llvm::APInt's div functions, which crash on zero value
divisors.

To fix this, we check if the Divisor is a zero constant. If it is, then
we record this UB and simply return a KLEE constant zero rather than going
through KLEE's api(s) such as SDivExpr::create.
