### PR TITLE
redis refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,15 @@ add_library(souperExtractor STATIC
   ${SOUPER_EXTRACTOR_FILES}
 )
 
+set(SOUPER_KVSTORE_FILES
+  lib/KVStore/KVStore.cpp
+  include/souper/KVStore/KVStore.h
+)
+
+add_library(souperKVStore STATIC
+  ${SOUPER_KVSTORE_FILES}
+)
+
 set(SOUPER_INST_FILES
   lib/Inst/Inst.cpp
   include/souper/Inst/Inst.h
@@ -166,6 +175,7 @@ add_library(souperPass SHARED
   ${KLEE_EXPR_FILES}
   ${SOUPER_EXTRACTOR_FILES}
   ${SOUPER_INST_FILES}
+  ${SOUPER_KVSTORE_FILES}
   ${SOUPER_PARSER_FILES}
   ${SOUPER_SMTLIB2_FILES}
   ${SOUPER_TOOL_FILES}
@@ -208,7 +218,7 @@ add_executable(parser_tests
   unittests/Parser/ParserTests.cpp
 )
 
-set_target_properties(souper internal-solver-test lexer-test parser-test souper-check souperExtractor souperInst souperParser souperSMTLIB2 souperTool souperPass kleeExpr
+set_target_properties(souper internal-solver-test lexer-test parser-test souper-check souperExtractor souperInst souperKVStore souperParser souperSMTLIB2 souperTool souperPass kleeExpr
   PROPERTIES COMPILE_FLAGS "${LLVM_CXXFLAGS}")
 set_target_properties(souperClangTool clang-souper
   PROPERTIES COMPILE_FLAGS "${CLANG_CXXFLAGS} ${LLVM_CXXFLAGS}")
@@ -219,16 +229,17 @@ target_link_libraries(kleeExpr ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperClangTool souperExtractor souperTool ${CLANG_LIBS} ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperExtractor souperInst kleeExpr)
 target_link_libraries(souperInst ${LLVM_LIBS} ${LLVM_LDFLAGS})
+target_link_libraries(souperKVStore ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperParser souperInst ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperSMTLIB2 ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperTool souperExtractor souperSMTLIB2)
 target_link_libraries(souperPass ${PASS_LDFLAGS} ${HIREDIS_LIBRARY})
-target_link_libraries(souper souperExtractor souperParser souperSMTLIB2 souperTool kleeExpr ${HIREDIS_LIBRARY})
+target_link_libraries(souper souperExtractor souperKVStore souperParser souperSMTLIB2 souperTool kleeExpr ${HIREDIS_LIBRARY})
 target_link_libraries(internal-solver-test souperSMTLIB2)
 target_link_libraries(lexer-test souperParser)
 target_link_libraries(parser-test souperParser)
-target_link_libraries(souper-check souperTool souperExtractor souperSMTLIB2 souperParser souperInst ${HIREDIS_LIBRARY})
-target_link_libraries(clang-souper souperClangTool souperExtractor souperParser souperSMTLIB2 souperTool kleeExpr ${CLANG_LIBS} ${LLVM_LIBS} ${LLVM_LDFLAGS} ${HIREDIS_LIBRARY})
+target_link_libraries(souper-check souperTool souperExtractor souperKVStore souperSMTLIB2 souperParser souperInst ${HIREDIS_LIBRARY})
+target_link_libraries(clang-souper souperClangTool souperExtractor souperKVStore souperParser souperSMTLIB2 souperTool kleeExpr ${CLANG_LIBS} ${LLVM_LIBS} ${LLVM_LDFLAGS} ${HIREDIS_LIBRARY})
 target_link_libraries(extractor_tests souperExtractor ${GTEST_LIBS})
 target_link_libraries(inst_tests souperInst ${GTEST_LIBS})
 target_link_libraries(parser_tests souperParser ${GTEST_LIBS})
@@ -252,7 +263,7 @@ if(NOT GO_EXECUTABLE STREQUAL "GO_EXECUTABLE-NOTFOUND")
   set_target_properties(souperweb-backend
     PROPERTIES COMPILE_FLAGS "${LLVM_CXXFLAGS}")
 
-  target_link_libraries(souperweb-backend souperTool souperExtractor souperSMTLIB2 souperParser souperInst ${HIREDIS_LIBRARY})
+  target_link_libraries(souperweb-backend souperTool souperExtractor souperKVStore souperSMTLIB2 souperParser souperInst ${HIREDIS_LIBRARY})
 
   add_custom_target(souperweb ALL COMMAND ${GO_EXECUTABLE} build -o ${CMAKE_BINARY_DIR}/souperweb ${CMAKE_SOURCE_DIR}/tools/souperweb.go
                                   COMMENT "Building souperweb")

--- a/include/souper/Extractor/Solver.h
+++ b/include/souper/Extractor/Solver.h
@@ -16,6 +16,7 @@
 #define SOUPER_EXTRACTOR_SOLVER_H
 
 #include "llvm/ADT/APInt.h"
+#include "souper/KVStore/KVStore.h"
 #include "souper/Tool/CandidateMapUtils.h"
 #include "souper/Extractor/Candidates.h"
 #include "souper/SMTLIB2/Solver.h"
@@ -30,7 +31,7 @@ public:
   virtual ~Solver();
   virtual std::error_code
   infer(const std::vector<InstMapping> &PCs, Inst *LHS, Inst *&RHS,
-        const InstOrigin *O, InstContext &IC) = 0;
+        InstContext &IC) = 0;
   virtual std::error_code
   isValid(const std::vector<InstMapping> &PCs, InstMapping Mapping,
           bool &IsValid,
@@ -42,8 +43,8 @@ std::unique_ptr<Solver> createBaseSolver(
     std::unique_ptr<SMTLIBSolver> SMTSolver, unsigned Timeout);
 std::unique_ptr<Solver> createMemCachingSolver(
     std::unique_ptr<Solver> UnderlyingSolver);
-std::unique_ptr<Solver> createRedisCachingSolver(
-    std::unique_ptr<Solver> UnderlyingSolver);
+std::unique_ptr<Solver> createExternalCachingSolver(
+    std::unique_ptr<Solver> UnderlyingSolver, KVStore *KV);
 
 }
 

--- a/include/souper/KVStore/KVStore.h
+++ b/include/souper/KVStore/KVStore.h
@@ -1,0 +1,36 @@
+// Copyright 2014 The Souper Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOUPER_KVSTORE_KVSTORE_H
+#define SOUPER_KVSTORE_KVSTORE_H
+
+#include "llvm/ADT/StringRef.h"
+#include <memory>
+
+namespace souper {
+
+class KVStore {
+  class KVImpl;
+  std::unique_ptr<KVImpl> Impl;
+public:
+  KVStore();
+  ~KVStore();
+  void hIncrBy(llvm::StringRef Key, llvm::StringRef Field, int Incr);
+  bool hGet(llvm::StringRef Key, llvm::StringRef Field, std::string &Value);
+  void hSet(llvm::StringRef Key, llvm::StringRef Field, llvm::StringRef Value);
+};
+
+}
+
+#endif  // SOUPER_KVSTORE_KVSTORE_H

--- a/include/souper/Tool/CandidateMapUtils.h
+++ b/include/souper/Tool/CandidateMapUtils.h
@@ -19,6 +19,7 @@
 #include "souper/Extractor/Candidates.h"
 #include "souper/Extractor/KLEEBuilder.h"
 #include "souper/Extractor/Solver.h"
+#include "souper/KVStore/KVStore.h"
 
 namespace llvm {
 
@@ -38,7 +39,8 @@ void AddModuleToCandidateMap(InstContext &IC, ExprBuilderContext &EBC,
                              CandidateMap &CandMap, llvm::Module *M);
 
 bool SolveCandidateMap(llvm::raw_ostream &OS, CandidateMap &M,
-                       Solver *Solver, InstContext &IC);
+                       Solver *Solver, InstContext &IC,
+                       KVStore *KVForStaticProfile);
 
 bool CheckCandidateMap(llvm::Module &Mod, CandidateMap &M, Solver *S,
                        InstContext &IC);

--- a/lib/KVStore/KVStore.cpp
+++ b/lib/KVStore/KVStore.cpp
@@ -1,0 +1,124 @@
+// Copyright 2014 The Souper Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "souper/KVStore/KVStore.h"
+
+#include "llvm/Support/CommandLine.h"
+#include "hiredis.h"
+
+using namespace llvm;
+using namespace souper;
+
+static cl::opt<unsigned> RedisPort("souper-redis-port", cl::init(6379),
+    cl::desc("Redis server port (default=6379)"));
+
+namespace souper {
+
+class KVStore::KVImpl {
+  redisContext *Ctx;
+public:
+  KVImpl();
+  ~KVImpl();
+  void hIncrBy(llvm::StringRef Key, llvm::StringRef Field, int Incr);
+  bool hGet(llvm::StringRef Key, llvm::StringRef Field, std::string &Value);
+  void hSet(llvm::StringRef Key, llvm::StringRef Field, llvm::StringRef Value);
+};
+
+KVStore::KVImpl::KVImpl() {
+  const char *hostname = "127.0.0.1";
+  struct timeval Timeout = { 1, 500000 }; // 1.5 seconds
+  Ctx = redisConnectWithTimeout(hostname, RedisPort, Timeout);
+  if (!Ctx) {
+    llvm::report_fatal_error("Can't allocate redis context\n");
+  }
+  if (Ctx->err) {
+    llvm::report_fatal_error((llvm::StringRef)"Redis connection error: " +
+                             Ctx->errstr + "\n");
+  }
+}
+
+KVStore::KVImpl::~KVImpl() {
+  redisFree(Ctx);
+}
+
+void KVStore::KVImpl::hIncrBy(llvm::StringRef Key, llvm::StringRef Field,
+                              int Incr) {
+  redisReply *reply = (redisReply *)redisCommand(Ctx, "HINCRBY %s %s 1",
+                                                 Key.data(), Field.data());
+  if (!reply || Ctx->err) {
+    llvm::report_fatal_error((llvm::StringRef)"Redis error: " + Ctx->errstr);
+  }
+  if (reply->type != REDIS_REPLY_INTEGER) {
+    llvm::report_fatal_error(
+        "Redis protocol error for static profile, didn't expect reply type "
+        + std::to_string(reply->type));
+  }
+  freeReplyObject(reply);
+}
+
+bool KVStore::KVImpl::hGet(llvm::StringRef Key, llvm::StringRef Field,
+                           std::string &Value) {
+  redisReply *reply = (redisReply *)redisCommand(Ctx, "HGET %s %s", Key.data(),
+                                                 Field.data());
+  if (!reply || Ctx->err) {
+    llvm::report_fatal_error((llvm::StringRef)"Redis error: " + Ctx->errstr);
+  }
+  if (reply->type == REDIS_REPLY_NIL) {
+    freeReplyObject(reply);
+    return false;
+  } else if (reply->type == REDIS_REPLY_STRING) {
+    Value = reply->str;
+    freeReplyObject(reply);
+    return true;
+  } else {
+    llvm::report_fatal_error(
+        "Redis protocol error for cache lookup, didn't expect reply type " +
+        std::to_string(reply->type));
+  }
+}
+
+void KVStore::KVImpl::hSet(llvm::StringRef Key, llvm::StringRef Field,
+                              llvm::StringRef Value) {
+  redisReply *reply = (redisReply *)redisCommand(Ctx, "HSET %s %s %s",
+      Key.data(), Field.data(), Value.data());
+  if (!reply || Ctx->err) {
+    llvm::report_fatal_error((llvm::StringRef)"Redis error: " + Ctx->errstr);
+  }
+  if (reply->type != REDIS_REPLY_INTEGER) {
+    llvm::report_fatal_error(
+        "Redis protocol error for cache fill, didn't expect reply type " +
+        std::to_string(reply->type));
+  }
+  freeReplyObject(reply);
+}
+
+KVStore::KVStore() : Impl (new KVImpl) {}
+
+KVStore::~KVStore() {}
+
+void KVStore::hIncrBy(llvm::StringRef Key, llvm::StringRef Field, int Incr) {
+  Impl->hIncrBy(Key, Field, Incr);
+}
+
+bool KVStore::hGet(llvm::StringRef Key, llvm::StringRef Field,
+                   std::string &Value) {
+  return Impl->hGet(Key, Field, Value);
+}
+
+void KVStore::hSet(llvm::StringRef Key, llvm::StringRef Field,
+                   llvm::StringRef Value) {
+  Impl->hSet(Key, Field, Value);
+}
+
+}

--- a/lib/Pass/Pass.cpp
+++ b/lib/Pass/Pass.cpp
@@ -24,6 +24,7 @@
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
+#include "souper/KVStore/KVStore.h"
 #include "souper/SMTLIB2/Solver.h"
 #include "souper/Tool/GetSolverFromArgs.h"
 #include "souper/Tool/CandidateMapUtils.h"
@@ -34,6 +35,7 @@ using namespace llvm;
 namespace {
 std::unique_ptr<Solver> S;
 unsigned ReplaceCount;
+KVStore *KV;
 
 static cl::opt<bool> DebugSouperPass("souper-debug", cl::Hidden,
                                      cl::init(false), cl::desc("Debug Souper"));
@@ -44,8 +46,11 @@ static cl::opt<unsigned> DebugLevel("souper-debug-level", cl::Hidden,
      "The larger the number is, the more fine-grained debug "
      "information will be printed."));
 
-static cl::opt<bool> ProfileSouperOpts("souper-profile-opts", cl::init(false),
-                                       cl::desc("Profile Souper optimizations"));
+static cl::opt<bool> DynamicProfile("souper-dynamic-profile", cl::init(false),
+    cl::desc("Dynamic profiling of Souper optimizations (default=false)"));
+
+static cl::opt<bool> StaticProfile("souper-static-profile", cl::init(false),
+    cl::desc("Static profiling of Souper optimizations (default=false)"));
 
 static cl::opt<bool> IgnoreSolverErrors("souper-ignore-solver-errors",
                                         cl::init(false),
@@ -69,7 +74,9 @@ struct SouperPass : public FunctionPass {
 public:
   SouperPass() : FunctionPass(ID) {
     if (!S) {
-      S = GetSolverFromArgs();
+      S = GetSolverFromArgs(KV);
+      if (StaticProfile && !KV)
+        KV = new KVStore;
       if (!S)
         report_fatal_error("Souper requires a solver to be specified");
     }
@@ -79,7 +86,7 @@ public:
     Info.addRequired<LoopInfo>();
   }
 
-  void addProfileCode(LLVMContext &C, Module *M, std::string LHS,
+  void dynamicProfile(LLVMContext &C, Module *M, std::string LHS,
                       std::string SrcLoc, BasicBlock::iterator BI) {
     Function *RegisterFunc = M->getFunction("_souper_profile_register");
     if (!RegisterFunc) {
@@ -174,9 +181,17 @@ public:
     }
 
     for (auto &Cand : CandMap) {
+      if (StaticProfile) {
+        std::string Str;
+        llvm::raw_string_ostream Loc(Str);
+        Instruction *I = Cand.Origin.getInstruction();
+        I->getDebugLoc().print(I->getContext(), Loc);
+        std::string HField = "sprofile " + Loc.str();
+        KV->hIncrBy(GetReplacementLHSString(Cand.PCs, Cand.Mapping.LHS), HField,
+                    1);
+      }
       if (std::error_code EC =
-              S->infer(Cand.PCs, Cand.Mapping.LHS, Cand.Mapping.RHS,
-                       &Cand.Origin, IC)) {
+          S->infer(Cand.PCs, Cand.Mapping.LHS, Cand.Mapping.RHS, IC)) {
         if (EC == std::errc::timed_out)
           continue;
         if (IgnoreSolverErrors) {
@@ -205,11 +220,11 @@ public:
       if (ReplaceCount >= FirstReplace && ReplaceCount <= LastReplace) {
         BasicBlock::iterator BI = I;
         ReplaceInstWithValue(I->getParent()->getInstList(), BI, CI);
-        if (ProfileSouperOpts) {
+        if (DynamicProfile) {
           std::string Str;
           llvm::raw_string_ostream Loc(Str);
           I->getDebugLoc().print(I->getContext(), Loc);
-          addProfileCode (F.getContext(), F.getParent(),
+          dynamicProfile (F.getContext(), F.getParent(),
                           GetReplacementLHSString(Cand.PCs, Cand.Mapping.LHS),
                           Loc.str(), BI);
         }

--- a/lib/Tool/CandidateMapUtils.cpp
+++ b/lib/Tool/CandidateMapUtils.cpp
@@ -18,8 +18,13 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
+#include "souper/KVStore/KVStore.h"
 #include "souper/SMTLIB2/Solver.h"
+
+using namespace llvm;
 
 void souper::AddToCandidateMap(CandidateMap &M,
                                const CandidateReplacement &CR) {
@@ -41,7 +46,7 @@ void souper::AddModuleToCandidateMap(InstContext &IC, ExprBuilderContext &EBC,
 namespace souper {
 
 bool SolveCandidateMap(llvm::raw_ostream &OS, CandidateMap &M,
-                       Solver *S, InstContext &IC) {
+                       Solver *S, InstContext &IC, KVStore *KVForStaticProfile) {
   if (S) {
     OS << "; Listing valid replacements.\n";
     OS << "; Using solver: " << S->getName() << '\n';
@@ -64,9 +69,20 @@ bool SolveCandidateMap(llvm::raw_ostream &OS, CandidateMap &M,
       if (Profile[I] == 0)
         continue;
       auto &Cand = M[I];
+
+      if (KVForStaticProfile) {
+        std::string Str;
+        llvm::raw_string_ostream Loc(Str);
+        Instruction *I = Cand.Origin.getInstruction();
+        I->getDebugLoc().print(I->getContext(), Loc);
+        std::string HField = "sprofile " + Loc.str();
+        KVForStaticProfile->hIncrBy(GetReplacementLHSString(Cand.PCs,
+            Cand.Mapping.LHS), HField, 1);
+      }
+
       Inst *RHS;
       if (std::error_code EC =
-              S->infer(Cand.PCs, Cand.Mapping.LHS, RHS, &Cand.Origin, IC)) {
+              S->infer(Cand.PCs, Cand.Mapping.LHS, RHS, IC)) {
         llvm::errs() << "Unable to query solver: " << EC.message() << '\n';
         return false;
       }
@@ -103,7 +119,7 @@ bool CheckCandidateMap(llvm::Module &Mod, CandidateMap &M, Solver *S,
   for (auto &Cand : M) {
     Inst *RHS;
     if (std::error_code EC =
-            S->infer(Cand.PCs, Cand.Mapping.LHS, RHS, &Cand.Origin, IC)) {
+            S->infer(Cand.PCs, Cand.Mapping.LHS, RHS, IC)) {
       llvm::errs() << "Unable to query solver: " << EC.message() << '\n';
       return false;
     }

--- a/test/Pass/clang-pass-profile.c
+++ b/test/Pass/clang-pass-profile.c
@@ -1,6 +1,6 @@
 // REQUIRES: solver
 
-// RUN: env SOUPER_NO_EXTERNAL_CACHE=1 SOUPER_PROFILE=1 SOUPER_SOLVER=%solver %sclang -O %s -o %t
+// RUN: env SOUPER_NO_EXTERNAL_CACHE=1 SOUPER_DYNAMIC_PROFILE=1 SOUPER_SOLVER=%solver %sclang -O %s -o %t
 
 // RUN: env SOUPER_PROFILE_TO_STDOUT=1 %t 0 | FileCheck %s -check-prefix=ARG0
 // ARG0: count = 0

--- a/tools/clang-souper.cpp
+++ b/tools/clang-souper.cpp
@@ -50,6 +50,7 @@ int main(int argc, const char **argv) {
       getGlobalContext(), IC, EBC, OwnedMods, CandMap));
   Tool.run(Factory.get());
 
-  std::unique_ptr<Solver> S = GetSolverFromArgs();
-  return SolveCandidateMap(llvm::outs(), CandMap, S.get(), IC) ? 0 : 1;
+  KVStore *KV = 0;
+  std::unique_ptr<Solver> S = GetSolverFromArgs(KV);
+  return SolveCandidateMap(llvm::outs(), CandMap, S.get(), IC, 0) ? 0 : 1;
 }

--- a/tools/souper-check.cpp
+++ b/tools/souper-check.cpp
@@ -53,7 +53,7 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
 
   if (InferRHS) {
     if (std::error_code EC = S->infer(Rep.PCs, Rep.Mapping.LHS, Rep.Mapping.RHS,
-                                      0, IC)) {
+                                      IC)) {
       llvm::errs() << EC.message() << '\n';
       return 1;
     }
@@ -102,7 +102,8 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
 
 int main(int argc, char **argv) {
   cl::ParseCommandLineOptions(argc, argv);
-  std::unique_ptr<Solver> S = GetSolverFromArgs();
+  KVStore *KV = 0;
+  std::unique_ptr<Solver> S = GetSolverFromArgs(KV);
   if (!S) {
     llvm::errs() << "Specify a solver\n";
     return 1;

--- a/tools/souperweb-backend.cpp
+++ b/tools/souperweb-backend.cpp
@@ -40,7 +40,7 @@ void SolveIR(std::unique_ptr<MemoryBuffer> MB, Solver *S) {
 
     AddModuleToCandidateMap(IC, EBC, CandMap, M.get());
 
-    SolveCandidateMap(llvm::outs(), CandMap, S, IC);
+    SolveCandidateMap(llvm::outs(), CandMap, S, IC, 0);
   } else {
     Err.print(0, llvm::errs(), false);
   }
@@ -86,7 +86,8 @@ static llvm::cl::opt<std::string> Action("action", llvm::cl::init(""));
 
 int main(int argc, char **argv) {
   cl::ParseCommandLineOptions(argc, argv);
-  std::unique_ptr<Solver> S = GetSolverFromArgs();
+  KVStore *KV;
+  std::unique_ptr<Solver> S = GetSolverFromArgs(KV);
 
   auto MB = MemoryBuffer::getSTDIN();
   if (MB) {

--- a/utils/sclang.in
+++ b/utils/sclang.in
@@ -68,8 +68,12 @@ if ($souper) {
         push @ARGV, ("-mllvm", "-stats");
     }
 
-    if ($ENV{"SOUPER_PROFILE"}) {
-        push @ARGV, ("-g", "-mllvm", "-souper-profile-opts");
+    if ($ENV{"SOUPER_STATIC_PROFILE"}) {
+        push @ARGV, ("-mllvm", "-souper-static-profile");
+    }
+
+    if ($ENV{"SOUPER_DYNAMIC_PROFILE"}) {
+        push @ARGV, ("-g", "-mllvm", "-souper-dynamic-profile");
         if (linkp()) {
             push @ARGV, ("@PROFILE_LIBRARY@", "@HIREDIS_LIBRARY@");
         }


### PR DESCRIPTION
hide Redis in a KVStore class

perform static profiling properly

N.B. static profile counts for non-optimizations are off by 5x for the opt pass,
because the pass runs 5 times. I don't think we care since optimizations and
non-optimizations will always be ranked separately. profiling of
non-optimizations is a niche use case anyway.

also see this previously closed pull req:
https://github.com/google/souper/pull/96
