### PR TITLE
add a -souper-no-infer command line option that is useful for quickly...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,3 +278,4 @@ configure_file(${CMAKE_SOURCE_DIR}/utils/sclang.in ${CMAKE_BINARY_DIR}/sclang @O
 configure_file(${CMAKE_SOURCE_DIR}/utils/sclang.in ${CMAKE_BINARY_DIR}/sclang++ @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/utils/reduce.in ${CMAKE_BINARY_DIR}/reduce @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/utils/cache_dump.in ${CMAKE_BINARY_DIR}/cache_dump @ONLY)
+configure_file(${CMAKE_SOURCE_DIR}/utils/cache_infer.in ${CMAKE_BINARY_DIR}/cache_infer @ONLY)

--- a/tools/souper-check.cpp
+++ b/tools/souper-check.cpp
@@ -39,13 +39,21 @@ static cl::opt<bool> InferRHS("infer-rhs",
     cl::desc("Try to infer a RHS for a Souper LHS (default=false)"),
     cl::init(false));
 
+static cl::opt<bool> ParseOnly("parse-only",
+    cl::desc("Only parse the replacement, don't call isValid() (default=false)"),
+    cl::init(false));
+
+static cl::opt<bool> ParseLHSOnly("parse-lhs-only",
+    cl::desc("Only parse the LHS, don't call infer() (default=false)"),
+    cl::init(false));
+
 int SolveInst(const MemoryBufferRef &MB, Solver *S) {
   InstContext IC;
   std::string ErrStr;
 
   ParsedReplacement Rep;
   ReplacementContext Context;
-  if (InferRHS) {
+  if (InferRHS || ParseLHSOnly) {
     Rep = ParseReplacementLHS(IC, MB.getBufferIdentifier(), MB.getBuffer(),
                               Context, ErrStr);
   } else {
@@ -54,6 +62,11 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
   if (!ErrStr.empty()) {
     llvm::errs() << ErrStr << '\n';
     return 1;
+  }
+
+  if (ParseOnly || ParseLHSOnly) {
+    llvm::outs() << "; parsing successful\n";
+    return 0;
   }
 
   if (InferRHS) {
@@ -121,10 +134,13 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
 int main(int argc, char **argv) {
   cl::ParseCommandLineOptions(argc, argv);
   KVStore *KV = 0;
-  std::unique_ptr<Solver> S = GetSolverFromArgs(KV);
-  if (!S) {
-    llvm::errs() << "Specify a solver\n";
-    return 1;
+  std::unique_ptr<Solver> S = 0;
+  if (!ParseOnly && !ParseLHSOnly) {
+    S = GetSolverFromArgs(KV);
+    if (!S) {
+      llvm::errs() << "Specify a solver\n";
+      return 1;
+    }
   }
 
   auto MB = MemoryBuffer::getFileOrSTDIN(InputFilename);

--- a/utils/cache_dump.in
+++ b/utils/cache_dump.in
@@ -21,37 +21,33 @@ use Getopt::Long;
 use File::Temp;
 use Time::HiRes;
 
+my $need_solver = <<END;
+$0 requires the SOUPER_SOLVER environment variable to be defined, e.g. as
+-stp-path=/path/to/stp
+END
+my $solver = $ENV{"SOUPER_SOLVER"};
+die $need_solver unless $solver;
+
+my $check = "@CMAKE_BINARY_DIR@/souper-check -solver-timeout=15 ${solver}";
+
 sub runit ($) {
     my $cmd = shift;
     my $res = (system "$cmd");
     return $? >> 8;
 }
 
-my $cur_key = 0;
-my $last_time = 0;
-my $backsp = "\b";
-sub spinner() {
-    my $now = Time::HiRes::time();
-    return if (time() <= ($last_time + 0.1));
-    $last_time = time();
-    my @chars = ("-", "\\", "|", "/");
-    $cur_key = 0 if ($cur_key == @chars);
-    print $backsp . $chars[$cur_key];
-    $cur_key++;
-}
-
-# TODO: add a -verify option
-
 sub usage() {
     print <<'END';
 Options:
-  -raw         Dump all keys and values and exit, ignoring all other options
+  -merge       Merge optimizations that differ only in bitwidths and constants
   -noopts      Dump not-optimizations instead of optimizations
+  -noparse     Do not ensure that each LHS in the cache parses as Souper
   -sort=size|sprofile|dprofile
                Sort optimizations by increasing size (default), decreasing
                static profile count, or descreasing dynamic profile count
+  -raw         Dump all keys and values and exit, ignoring all other options
   -reduce      Attempt to reduce the size of each optimization
-  -merge       Merge optimizations that differ only in bitwidths and constants
+  -verify      Verify each optimization
 END
     exit -1;
 }
@@ -61,16 +57,18 @@ my $NOOPTS = 0;
 my $SORT = "size";
 my $REDUCE = 0;
 my $MERGE = 0;
+my $NOPARSE = 0;
+my $VERIFY = 0;
 GetOptions(
-    "raw"  => \$RAW,
-    "noopts" => \$NOOPTS,
-    "sort=s" => \$SORT,
-    "reduce" => \$REDUCE,
     "merge" => \$MERGE,
+    "noopts" => \$NOOPTS,
+    "noparse" => \$NOPARSE,
+    "sort=s" => \$SORT,
+    "raw"  => \$RAW,
+    "reduce" => \$REDUCE,
+    "verify" => \$VERIFY,
     ) or usage();
 usage() unless ($SORT eq "size" || $SORT eq "sprofile" || $SORT eq "dprofile");
-die "-reduce and -noopts cannot be used together" if ($REDUCE && $NOOPTS);
-die "-merge and -noopts cannot be used together" if ($MERGE && $NOOPTS);
 
 my $reducer = "@CMAKE_BINARY_DIR@/reduce";
 
@@ -88,9 +86,9 @@ $r->ping || die "no server?";
 my @keys = $r->keys('*');
 
 if ($RAW) {
-    foreach my $k (@keys) {
-        my %h = $r->hgetall($k);
-        print "<$k>\n";
+    foreach my $LHS (sort @keys) {
+        my %h = $r->hgetall($LHS);
+        print "<$LHS>\n";
         foreach my $kk (sort keys %h) {
             print "  <$kk> <$h{$kk}>\n";
         }
@@ -102,12 +100,42 @@ if ($RAW) {
 
 print "\nGrabbing Redis values...";
 
-foreach my $k (@keys) {
-    spinner();
-    my %h = $r->hgetall($k);
+sub parse ($$) {
+    (my $LHS, my $RHS) = @_;
+    (my $fh, my $tmpfn) = File::Temp::tempfile();
+    print $fh $LHS;
+    $fh->flush();
+    my $arg;
+    if ($VERIFY) {
+        $arg = "--infer-rhs";
+    } else {
+        $arg = "--parse-lhs-only";
+    }
+    open INF, "${check} $arg < $tmpfn 2>/dev/null |";
+    my $output = "";
+    my $success = 0;
+    while (my $line = <INF>) {
+        $success = 1 if ($line =~ /success/);
+        next if ($line =~ /^;/);
+        $output .= $line;
+    }
+    close INF;
+    close $fh;
+    unlink $tmpfn;
+    if ($VERIFY) {
+        die "expected '$RHS' but souper-check returned '$output'" unless
+            ($output eq $RHS);
+    } else {
+        die "'$LHS' does not parse as Souper" unless $success;
+    }
+}
+
+foreach my $LHS (@keys) {
+    my %h = $r->hgetall($LHS);
     my $result = $h{"result"};
-    if (!defined($result)) {
-        print STDERR "WARNING: no result for key\n";
+    if (defined($result)) {
+        parse($LHS, $result) unless $NOPARSE;
+    } else {
         next;
     }
     my $sprofile = 0;
@@ -120,16 +148,16 @@ foreach my $k (@keys) {
             $dprofile += $h{$kk};
         }
     }
-    $k .= $result;
+    $LHS .= $result;
     if ($result eq "") {
         $noopt_count++;
-        $toprint{$k} = 1 if $NOOPTS;
+        $toprint{$LHS} = 1 if $NOOPTS;
     } else {
         $opt_count++;
-        $toprint{$k} = 1 if !$NOOPTS;
+        $toprint{$LHS} = 1 if !$NOOPTS;
     }
-    $sprofiles{$k} = $sprofile;
-    $dprofiles{$k} = $dprofile;
+    $sprofiles{$LHS} = $sprofile;
+    $dprofiles{$LHS} = $dprofile;
 }
 
 sub replace($$) {
@@ -145,11 +173,10 @@ if ($REDUCE) {
     print "\nReducing...";
 
     my @keys = keys %toprint;
-    foreach my $k (@keys) {
-        spinner();
+    foreach my $LHS (@keys) {
         (my $fh1, my $fn1) = File::Temp::tempfile();
         (my $fh2, my $fn2) = File::Temp::tempfile();
-        print $fh1 $k;
+        print $fh1 $LHS;
         close $fh1;
         close $fh2;
         runit ("$reducer < $fn1 > $fn2") == 0 or die;
@@ -162,10 +189,10 @@ if ($REDUCE) {
         unlink $fn1;
         unlink $fn2;
         if ($new eq "") {
-            print "can't reduce $k\n";
+            print "can't reduce $LHS\n";
             die;
         } else {
-            replace($k, $new);
+            replace($LHS, $new);
         }
     }
 }
@@ -174,12 +201,11 @@ if ($MERGE) {
     print "\nMerging...";
 
     my @keys = keys %toprint;
-    foreach my $k (@keys) {
-        spinner();
-        my $new = $k;
+    foreach my $LHS (@keys) {
+        my $new = $LHS;
         $new =~ s/:i[0-9]+//g;
         $new =~ s/ [0-9]+/ C/g;
-        replace($k, $new);
+        replace($LHS, $new);
     }
 }
 
@@ -196,10 +222,10 @@ my $byx = \&bylen;
 $byx = \&bysprofile if ($SORT eq "sprofile");
 $byx = \&bydprofile if ($SORT eq "dprofile");
 
-foreach my $k (sort $byx keys %toprint) {
-    print "$k";
+foreach my $LHS (sort $byx keys %toprint) {
+    print "$LHS";
     print "\n";
-    print "; sprofile = $sprofiles{$k}\n";
-    print "; dprofile = $dprofiles{$k}\n";
+    print "; sprofile = $sprofiles{$LHS}\n";
+    print "; dprofile = $dprofiles{$LHS}\n";
     print "------------------------------------------------------\n\n";
 }

--- a/utils/cache_infer.in
+++ b/utils/cache_infer.in
@@ -1,0 +1,112 @@
+#!/usr/bin/env perl
+
+# Copyright 2014 The Souper Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use warnings;
+use strict;
+use Redis;
+use Getopt::Long;
+use File::Temp;
+use Time::HiRes;
+
+eval { require Sys::CPU; Sys::CPU->import(); };
+
+my $NPROCS = 4;
+$NPROCS = Sys::CPU::cpu_count() if defined(&Sys::CPU::cpu_count);
+
+sub usage() {
+    print <<"END";
+Options:
+  -n           number of CPUs to use (default=$NPROCS)
+END
+    exit -1;
+}
+
+GetOptions(
+    "n=i" => \$NPROCS,
+    ) or usage();
+
+my $need_solver = <<END;
+$0 requires the SOUPER_SOLVER environment variable to be defined, e.g. as
+-stp-path=/path/to/stp
+END
+my $solver = $ENV{"SOUPER_SOLVER"};
+die $need_solver unless $solver;
+
+my $check = "@CMAKE_BINARY_DIR@/souper-check -solver-timeout=15 ${solver}";
+
+sub runit ($) {
+    my $cmd = shift;
+    my $res = (system "$cmd");
+    return $? >> 8;
+}
+
+my $r = Redis->new();
+$r->ping || die "no server?";
+my @keys = $r->keys('*');
+
+sub infer($) {
+    (my $k) = @_;
+    (my $fh, my $tmpfn) = File::Temp::tempfile();
+    print $fh $k;
+    $fh->flush();
+    open INF, "${check} -infer-rhs -souper-external-cache < $tmpfn |";
+    my $ok = 0;
+    my $output = "";
+    while (my $line = <INF>) {
+        exit 1 if ($line =~ /Failed/);
+        if ($line =~ /successfully/) {
+            $ok = 1;
+            next;
+        }
+        $output .= $line;
+    }
+    exit 1 unless $ok;
+    exit 0;
+}
+
+my $num_running = 0;
+my $good = 0;
+my $fail = 0;
+
+sub wait_for_one() {
+    my $xpid = wait();
+    die if $xpid == -1;
+    $num_running--;
+    my $result = $? >> 8;
+    if ($result == 0) {
+        $good++;
+    } else {
+        $fail++;
+    }
+}
+
+my $opid = $$;
+
+foreach my $k (@keys) {
+    wait_for_one() unless $num_running < $NPROCS;
+    die unless $num_running < $NPROCS;
+    my $pid = fork();
+    die unless $pid >= 0;
+    infer ($k) if $pid == 0;
+    # make sure we're in the parent
+    die unless $$ == $opid;
+    $num_running++;
+}
+
+wait_for_one() while ($num_running > 0);
+
+print "$good optimizations\n";
+print "$fail not-optimizations\n";

--- a/utils/reduce.in
+++ b/utils/reduce.in
@@ -18,25 +18,30 @@ use warnings;
 use strict;
 use File::Temp;
 
+my $usage = <<END;
+$0 requires the SOUPER_SOLVER environment variable to be defined, e.g. as
+-stp-path=/path/to/stp
+END
 my $solver = $ENV{"SOUPER_SOLVER"};
-die "$0 requires the SOUPER_SOLVER environment variable to be defined, e.g. as -stp-path=/path/to/stp" unless $solver;
-my $SOUPER_CHECK = "@CMAKE_BINARY_DIR@/souper-check -solver-timeout=15 ${solver}";
+die $usage unless $solver;
+
+my $check = "@CMAKE_BINARY_DIR@/souper-check -solver-timeout=15 ${solver}";
 
 sub check ($) {
     (my $s) = @_;
     (my $fh, my $tmpfn) = File::Temp::tempfile();
     print $fh $s;
     $fh->flush();
-    open INF, "${SOUPER_CHECK} --print-replacement < $tmpfn 2>/dev/null |";
-    my $s2 = "";
+    open INF, "${check} --print-replacement < $tmpfn 2>/dev/null |";
+    my $output = "";
     while (my $line = <INF>) {
         chomp $line;
-        $s2 .= $line;
+        $output .= $line;
     }
     close INF;
     close $fh;
     unlink $tmpfn;
-    return 0 if ($s2 =~ "LGTM");
+    return 0 if ($output =~ "LGTM");
     return 1;
 }
 
@@ -237,7 +242,7 @@ sub pretty ($) {
     open OUTF, ">$tmpfn" or die;
     print OUTF $red;
     close OUTF;
-    open INF, "${SOUPER_CHECK} --print-replacement $tmpfn |";
+    open INF, "${check} --print-replacement $tmpfn |";
     my $foo = <INF>;
     my $pret = "";
     while (my $line = <INF>) {

--- a/utils/sclang.in
+++ b/utils/sclang.in
@@ -56,16 +56,16 @@ if ($souper) {
         "-mllvm", "-solver-timeout=15",
     );
 
-    if (!$ENV{"SOUPER_NO_EXTERNAL_CACHE"}) {
-        push @ARGV, ("-mllvm", "-souper-external-cache");
-    }
-
     if ($ENV{"SOUPER_DEBUG"}) {
         push @ARGV, ("-mllvm", "-souper-debug");
     }
 
-    if ($ENV{"SOUPER_STATS"}) {
-        push @ARGV, ("-mllvm", "-stats");
+    if (!$ENV{"SOUPER_NO_EXTERNAL_CACHE"}) {
+        push @ARGV, ("-mllvm", "-souper-external-cache");
+    }
+
+    if ($ENV{"SOUPER_NO_INFER"}) {
+        push @ARGV, ("-mllvm", "-souper-no-infer");
     }
 
     if ($ENV{"SOUPER_STATIC_PROFILE"}) {
@@ -77,6 +77,10 @@ if ($souper) {
         if (linkp()) {
             push @ARGV, ("@PROFILE_LIBRARY@", "@HIREDIS_LIBRARY@");
         }
+    }
+
+    if ($ENV{"SOUPER_STATS"}) {
+        push @ARGV, ("-mllvm", "-stats");
     }
 }
 


### PR DESCRIPTION
loading LHSs into the cache

add a tool cache_infer that runs infer() on each LHS in the cache; this is
useful for doing synthesis work without dealing with the tedium of building
software; it automatically uses all CPUs

add a couple of "parse only" options to souper-check so that cache_dump can
ensure that cache LHSs parse without incurrent the cost of running the solver

remove the spinner from cache_dump

a bit of refactoring in cache_dump
