### PR TITLE
don't store UntypedInt with 4-bit APInt values

### DIFF
--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -198,7 +198,7 @@ FoundChar:
     }
 
     return Token{Token::UntypedInt, NumBegin, size_t(Begin - NumBegin),
-                 APInt((NumEnd - NumBegin) * 4,
+                 APInt((NumEnd - NumBegin) * 5,
                         StringRef(NumBegin, NumEnd - NumBegin), 10)};
   }
 

--- a/unittests/Parser/ParserTests.cpp
+++ b/unittests/Parser/ParserTests.cpp
@@ -557,3 +557,51 @@ cand %4 %7
     EXPECT_EQ(T.Test, UnSplit);
   }
 }
+
+TEST(ParserTest, ExpectedReplacement) {
+  struct {
+    std::string Test;
+    std::string ExpectedReplacement;
+  } Tests[] = {
+      { R"i(%0:i8 = var ; 0
+%1:i1 = eq 1, %0
+%2:i1 = eq 2, %0
+%3:i1 = eq 4, %0
+%4:i1 = eq 8, %0
+%5:i1 = eq 16, %0
+%6:i1 = eq 32, %0
+%7:i1 = eq 64, %0
+%8:i1 = eq 128, %0
+%9:i1 = or %1, %2, %3, %4, %5, %6, %7, %8
+%10:i1 = eq 1, %9
+cand %9 %10
+)i",
+        R"i(%0:i8 = var ; 0
+%1:i1 = eq 1:i8, %0
+%2:i1 = eq 2:i8, %0
+%3:i1 = eq 4:i8, %0
+%4:i1 = eq 8:i8, %0
+%5:i1 = eq 16:i8, %0
+%6:i1 = eq 32:i8, %0
+%7:i1 = eq 64:i8, %0
+%8:i1 = eq 128:i8, %0
+%9:i1 = or %1, %2, %3, %4, %5, %6, %7, %8
+%10:i1 = eq 1:i1, %9
+cand %9 %10
+
+)i" },
+  };
+
+  InstContext IC;
+  for (const auto &T : Tests) {
+    std::string ErrStr;
+    auto R = ParseReplacements(IC, "<input>", T.Test, ErrStr);
+    EXPECT_EQ("", ErrStr);
+
+    std::string Replacement;
+    for (auto I = R.begin(); I != R.end(); ++I) {
+      Replacement += I->getString(/*printNames=*/true) + '\n';
+    }
+    EXPECT_EQ(T.ExpectedReplacement, Replacement);
+  }
+}


### PR DESCRIPTION
Integer 8 is represent as b1000 in a 4-bit APInt manner.
Later, when we translate this APInt value into a const using
APInt.sextOrTrunc, we get b11111000 back, which is not what
we want. The bad intepretation only occurs when
we infer the type of an integer, i.e., an integer without :iN.
Note that b11111000 is unsigned char 248, which is why we see
instruction "%8:i1 = eq 248:i8, %0" in John's example.

The fix is to use multiple of 5. It should always be safe.
Also, we won't increase too much memory usage because
it's only for parsing replacements, which are small.
