### PR TITLE
first cut at supporting "nop synthesis" in the opt pass

### DIFF
--- a/include/souper/Inst/Inst.h
+++ b/include/souper/Inst/Inst.h
@@ -23,6 +23,12 @@
 #include <vector>
 #include <map>
 
+namespace llvm {
+
+class Value;
+
+}
+
 namespace souper {
 
 struct Block {
@@ -91,7 +97,9 @@ struct Inst : llvm::FoldingSetNode {
   std::string Name;
   std::vector<Inst *> Ops;
   mutable std::vector<Inst *> OrderedOps;
+  llvm::Value *Origin;
 
+  Inst() : Origin() {}
   bool operator<(const Inst &I) const;
   const std::vector<Inst *> &orderedOps() const;
 

--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -400,6 +400,7 @@ Inst *ExprBuilder::get(Value *V) {
   Inst *&E = EBC.InstMap[V];
   if (!E) {
     E = build(V);
+    E->Origin = V;
   }
   return E;
 }


### PR DESCRIPTION
Peter, could you check if this seems to be on the right track?

While building gzip using this + Raimondas's nop inference, I got an "Instruction does not dominate all uses!" so I know that there is something I've failed to take into account.

"nop inference" is what we have been calling the phenomenon when an LLVM value can be proven to be equal to some other value that was available earlier. It's a degenerate case of synthesis that I thought would be useful to handle in the opt pass before moving on to more interesting stuff.
