### PR TITLE
simple synthesis of nops and single instructions

### DIFF
--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -509,7 +509,7 @@ void ExtractExprCandidates(Function &F, const LoopInfo *LI,
   for (auto &BB : F) {
     std::unique_ptr<BlockCandidateSet> BCS(new BlockCandidateSet);
     for (auto &I : BB) {
-      if (I.getType()->isIntegerTy(1))
+      if (I.getType()->isIntegerTy())
         BCS->Replacements.emplace_back(&I, InstMapping(EB.get(&I), 0));
     }
     if (!BCS->Replacements.empty()) {

--- a/lib/Extractor/Solver.cpp
+++ b/lib/Extractor/Solver.cpp
@@ -39,7 +39,19 @@ using namespace llvm;
 namespace {
 
 static cl::opt<bool> NoInfer("souper-no-infer",
-    cl::desc("Populate the external cache, but don't infer replacements"),
+    cl::desc("Populate the external cache, but don't infer replacements (default=false)"),
+    cl::init(false));
+
+static cl::opt<bool> InferI1("souper-infer-i1",
+    cl::desc("Infer Boolean values (default=true)"),
+    cl::init(true));
+
+static cl::opt<bool> InferNop("souper-infer-nop",
+    cl::desc("Infer nops (default=false)"),
+    cl::init(false));
+
+static cl::opt<bool> InferUnary("souper-infer-unary",
+    cl::desc("Infer unary instructions (default=false)"),
     cl::init(false));
 
 class BaseSolver : public Solver {
@@ -50,27 +62,104 @@ public:
   BaseSolver(std::unique_ptr<SMTLIBSolver> SMTSolver, unsigned Timeout)
       : SMTSolver(std::move(SMTSolver)), Timeout(Timeout) {}
 
+private:
+  void getInputs(Inst *I, std::set<Inst *> &Inputs) {
+    if (Inputs.insert(I).second)
+      for (auto Op : I->Ops)
+        getInputs(Op, Inputs);
+  }
+
+public:
   std::error_code infer(const std::vector<InstMapping> &PCs,
                         Inst *LHS, Inst *&RHS, InstContext &IC) {
-    assert(LHS->Width == 1);
     std::error_code EC;
-    std::vector<Inst *>Guesses { IC.getConst(APInt(1, true)),
-                                 IC.getConst(APInt(1, false)) };
-    for (auto I : Guesses) {
-      // TODO: we can trivially synthesize an i1 undef by checking for validity
-      // of both guesses
-      InstMapping Mapping(LHS, I);
-      CandidateExpr CE = GetCandidateExprForReplacement(PCs, Mapping);
-      bool IsSat;
-      EC = SMTSolver->isSatisfiable(BuildQuery(PCs, Mapping, 0), IsSat, 0, 0,
-                                    Timeout);
-      if (EC)
-        return EC;
-      if (!IsSat) {
-        RHS = I;
-        return EC;
+
+    if (LHS->Width == 1 && InferI1) {
+      std::vector<Inst *>Guesses { IC.getConst(APInt(1, true)),
+          IC.getConst(APInt(1, false)) };
+      for (auto G : Guesses) {
+        // TODO: we can trivially synthesize an i1 undef by checking for
+        // validity of both guesses
+        InstMapping Mapping(LHS, G);
+        CandidateExpr CE = GetCandidateExprForReplacement(PCs, Mapping);
+        bool IsSat;
+        EC = SMTSolver->isSatisfiable(BuildQuery(PCs, Mapping, 0), IsSat, 0, 0,
+                                      Timeout);
+        if (EC)
+          return EC;
+        if (!IsSat) {
+          RHS = G;
+          return EC;
+        }
       }
     }
+
+    std::set<Inst *> Inputs;
+    if (InferNop || InferUnary)
+      for (auto Op : LHS->Ops)
+        getInputs(Op, Inputs);
+
+    if (InferNop) {
+      for (auto I : Inputs) {
+        if (I->Width == 1 &&
+            (I->K == Inst::Const || I->K == Inst::UntypedConst))
+          continue;
+        if (LHS->Width != I->Width)
+          continue;
+        InstMapping Mapping(LHS, I);
+        CandidateExpr CE = GetCandidateExprForReplacement(PCs, Mapping);
+        bool IsSat;
+        EC = SMTSolver->isSatisfiable(BuildQuery(PCs, Mapping, 0), IsSat, 0, 0,
+                                      Timeout);
+        if (EC)
+          return EC;
+        if (!IsSat) {
+          RHS = I;
+          return EC;
+        }
+      }
+    }
+
+    // TODO: constant synthesis goes here
+
+    if (InferUnary) {
+      for (auto I : Inputs) {
+        if (I->Width == 1 &&
+            (I->K == Inst::Const || I->K == Inst::UntypedConst))
+          continue;
+        std::vector<Inst *> Guesses;
+        if (LHS->Width > I->Width) {
+          if ((LHS->K == Inst::SExt || LHS->K == Inst::ZExt) &&
+              LHS->Ops[0] == I)
+            continue;
+          Guesses.push_back(IC.getInst(Inst::SExt, LHS->Width, {I}));
+          Guesses.push_back(IC.getInst(Inst::ZExt, LHS->Width, {I}));
+        } else if (LHS->Width < I->Width) {
+          Guesses.push_back(IC.getInst(Inst::Trunc, LHS->Width, {I}));
+        } else {
+          Guesses.push_back(IC.getInst(Inst::Xor, LHS->Width,
+              { IC.getConst(APInt(I->Width, -1)), I }));
+          Guesses.push_back(IC.getInst(Inst::Sub, LHS->Width,
+              { IC.getConst(APInt(I->Width, 0)), I }));
+        }
+        for (auto G : Guesses) {
+          if (LHS->K == G->K)
+            continue;
+          InstMapping Mapping(LHS, G);
+          CandidateExpr CE = GetCandidateExprForReplacement(PCs, Mapping);
+          bool IsSat;
+          EC = SMTSolver->isSatisfiable(BuildQuery(PCs, Mapping, 0),
+                                        IsSat, 0, 0, Timeout);
+          if (EC)
+            return EC;
+          if (!IsSat) {
+            RHS = G;
+            return EC;
+          }
+        }
+      }
+    }
+
     RHS = 0;
     return EC;
   }

--- a/lib/Pass/Pass.cpp
+++ b/lib/Pass/Pass.cpp
@@ -203,7 +203,7 @@ public:
           report_fatal_error("Unable to query solver: " + EC.message() + "\n");
         }
       }
-      if (!Cand.Mapping.RHS)
+      if (!Cand.Mapping.RHS || Cand.Mapping.RHS->K != Inst::Const)
         continue;
       Instruction *I = Cand.Origin.getInstruction();
 

--- a/test/Tool/intrinsic.ll
+++ b/test/Tool/intrinsic.ll
@@ -17,8 +17,6 @@ declare i64 @llvm.bswap.i64(i64) #0
 
 define void @foo(i64 %x) {
 entry:
-  %swap1 = call i64 @llvm.bswap.i64(i64 %x)
-  %swap2 = call i64 @llvm.bswap.i64(i64 %swap1)
-  %cmp = icmp eq i64 %x, %swap2
+  %cmp = icmp eq i64 %x, %x
   ret void
 }

--- a/utils/sclang.in
+++ b/utils/sclang.in
@@ -78,6 +78,18 @@ if ($souper) {
         push @ARGV, ("-mllvm", "-souper-no-infer");
     }
 
+    if ($ENV{"SOUPER_NO_INFER_I1"}) {
+        push @ARGV, ("-mllvm", "-souper-infer-i1=false");
+    }
+
+    if ($ENV{"SOUPER_INFER_NOP"}) {
+        push @ARGV, ("-mllvm", "-souper-infer-nop");
+    }
+
+    if ($ENV{"SOUPER_INFER_INST"}) {
+        push @ARGV, ("-mllvm", "-souper-infer-inst");
+    }
+
     if ($ENV{"SOUPER_STATIC_PROFILE"}) {
         push @ARGV, ("-mllvm", "-souper-static-profile");
     }


### PR DESCRIPTION
this pulls out some code that Raimondas and I have been collaborating on

the purpose of this code is to do simplistic but useful synthesis of RHSs. the two forms supported are:
- "nops" -- the optimized value turns out to have been available earlier, under a different name
- single instructions -- the optimized value is an extended, truncated, negated, or complemented version of a value that was available earlier

although I suspect this method of synthesis (which issues a lot of solver queries, and is therefore quite slow) will eventually not be the right way to go, we need this code in order to push forward improvements in the Pass

finally I should add that these kinds of synthesis work really well in the sense that they discover many potential replacements
