### PR TITLE
Handle instruction UB on the RHS correctly

### DIFF
--- a/test/Infer/ub-rhs1.opt
+++ b/test/Infer/ub-rhs1.opt
@@ -1,0 +1,13 @@
+; REQUIRES: solver
+; RUN: %souper-check %solver %s | FileCheck %s
+; CHECK: Invalid
+
+%0:i31 = var
+%1:i31 = var
+%2:i32 = zext %0
+%3:i32 = zext %1
+%4:i32 = add %2, %3
+infer %4
+
+%5:i32 = addnsw %2, %3
+result %5

--- a/test/Infer/ub-rhs2.opt
+++ b/test/Infer/ub-rhs2.opt
@@ -1,0 +1,13 @@
+; REQUIRES: solver
+; RUN: %souper-check %solver %s | FileCheck %s
+; CHECK: LGTM
+
+%0:i31 = var
+%1:i31 = var
+%2:i33 = zext %0
+%3:i33 = zext %1
+%4:i33 = add %2, %3
+infer %4
+
+%5:i33 = addnsw %2, %3
+result %5

--- a/test/Infer/ub-rhs3.opt
+++ b/test/Infer/ub-rhs3.opt
@@ -1,0 +1,14 @@
+; REQUIRES: solver
+; RUN: %souper-check %solver %s | FileCheck %s
+; CHECK: Invalid
+
+%0:i8 = var
+%1:i8 = var
+%2:i8 = var
+%3:i8 = mul %0, %1
+%4:i8 = shl %3, %2
+infer %4
+
+%5:i8 = shl %1, %2
+%6:i8 = mulnw %0, %5
+result %6

--- a/test/Infer/ub-rhs4.opt
+++ b/test/Infer/ub-rhs4.opt
@@ -1,0 +1,14 @@
+; REQUIRES: solver
+; RUN: %souper-check %solver %s | FileCheck %s
+; CHECK: LGTM
+
+%0:i8 = var
+%1:i8 = var
+%2:i8 = var
+%3:i8 = mul %0, %1
+%4:i8 = shl %3, %2
+infer %4
+
+%5:i8 = shl %1, %2
+%6:i8 = mul %0, %5
+result %6


### PR DESCRIPTION
This patch teaches Souper to hande UB on the RHS correctly (issue #107). It implements the following query

`LHS UB assertion => (LHS == RHS) && RHS UB assertion`

`GetCandidateExprForReplacement` function first builds the LHS and the corresponding UB constraints. Afterwards, the RHS is parsed reusing the same `ExprBuilder` context and the RHS UB constraints are collected. The side-effect of reusing the same parsing context results in inclusion of LHS constraints inside of RHS constraints, but these should be easily eliminated by the solver, because they are `true`.
