### PR TITLE
Remove ExprSMTLIBLetPrinter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,6 @@ set(KLEE_EXPR_FILES
   third_party/klee/lib/Expr/Expr.cpp
   third_party/klee/lib/Expr/ExprEvaluator.cpp
   third_party/klee/lib/Expr/ExprPPrinter.cpp
-  third_party/klee/lib/Expr/ExprSMTLIBLetPrinter.cpp
   third_party/klee/lib/Expr/ExprSMTLIBPrinter.cpp
   third_party/klee/lib/Expr/ExprUtil.cpp
   third_party/klee/lib/Expr/ExprVisitor.cpp

--- a/lib/Extractor/KLEEBuilder.cpp
+++ b/lib/Extractor/KLEEBuilder.cpp
@@ -16,7 +16,7 @@
 
 #include "klee/Expr.h"
 #include "klee/util/ExprPPrinter.h"
-#include "klee/util/ExprSMTLIBLetPrinter.h"
+#include "klee/util/ExprSMTLIBPrinter.h"
 #include "klee/util/Ref.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/IR/BasicBlock.h"
@@ -776,7 +776,7 @@ std::string souper::BuildQuery(const std::vector<InstMapping> &PCs,
   ConstraintManager Manager;
   CandidateExpr CE = GetCandidateExprForReplacement(PCs, Mapping);
   Query KQuery(Manager, CE.E);
-  ExprSMTLIBLetPrinter Printer;
+  ExprSMTLIBPrinter Printer;
   Printer.setOutput(SMTSS);
   Printer.setQuery(KQuery);
   std::vector<const klee::Array *> Arrays;

--- a/tools/souper.cpp
+++ b/tools/souper.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "klee/util/ExprSMTLIBLetPrinter.h"
 #include "klee/Solver.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Bitcode/ReaderWriter.h"

--- a/update_deps.sh
+++ b/update_deps.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 llvm_revision=223586
-klee_commit=0c8c812db1d331f1e49e27ccd35f1288e58d97e6
+klee_commit=5acb6356d1fdf6b87c8669e8eb88c720b8dc3ee9
 hiredis_commit=8f60ee65327445ed8384290b4040685329eb03c5
 
 llvm_build_type=Debug


### PR DESCRIPTION
This version of KLEE includes our patch to enable
nested let abbreviations.
