### PR TITLE
Add iN synthesis with two queries (no quantifiers)

### DIFF
--- a/include/souper/Extractor/KLEEBuilder.h
+++ b/include/souper/Extractor/KLEEBuilder.h
@@ -31,10 +31,11 @@ struct CandidateExpr {
 
 CandidateExpr GetCandidateExprForReplacement(const BlockPCs &BPCs,
                                              const std::vector<InstMapping> &PCs,
-                                             InstMapping Mapping);
+                                             InstMapping Mapping, bool Negate);
+
 std::string BuildQuery(const BlockPCs &BPCs,
                        const std::vector<InstMapping> &PCs, InstMapping Mapping,
-                       std::vector<Inst *> *ModelVars);
+                       std::vector<Inst *> *ModelVars, bool Negate=false);
 
 }
 

--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -616,7 +616,7 @@ void ExtractExprCandidates(Function &F, const LoopInfo *LI,
   for (auto &BB : F) {
     std::unique_ptr<BlockCandidateSet> BCS(new BlockCandidateSet);
     for (auto &I : BB) {
-      if (I.getType()->isIntegerTy(1))
+      if (I.getType()->isIntegerTy())
         BCS->Replacements.emplace_back(&I, InstMapping(EB.get(&I), 0));
     }
     if (!BCS->Replacements.empty()) {

--- a/lib/SMTLIB2/Solver.cpp
+++ b/lib/SMTLIB2/Solver.cpp
@@ -89,16 +89,30 @@ struct SMTLIBParser {
     return false;
   }
 
-  APInt parseModel(std::string &ErrStr) {
-    if (!consumeExpected('(', ErrStr))
-      return APInt();
-    if (!consumeExpected('(', ErrStr))
-      return APInt();
-    if (!consumeSExpr(ErrStr))
-      return APInt();
+  bool consumeBvName(std::string &ErrStr) {
+    while (Begin != End && (*Begin != ' ' && *Begin != '\n' && *Begin != '\r' &&
+                            *Begin != '\t'))
+      ++Begin;
+    if (Begin == End) {
+      ErrStr = "unexpected EOF";
+      return false;
+    }
+    return true;
+  }
 
-    if (!consumeExpected('(', ErrStr))
-      return APInt();
+  APInt parseBinaryBitVector(std::string &ErrStr) {
+    ErrStr.clear();
+    const char *NumBegin = Begin;
+    while (Begin != End && (*Begin == '0' || *Begin == '1'))
+      ++Begin;
+    const char *NumEnd = Begin;
+    unsigned Width = NumEnd - NumBegin;
+
+    return APInt(Width, StringRef(NumBegin, Width), 2);
+  }
+
+  APInt parseDecimalBitVector(std::string &ErrStr) {
+    ErrStr.clear();
     if (!consumeExpected('_', ErrStr))
       return APInt();
     if (!consumeExpected('b', ErrStr))
@@ -126,12 +140,47 @@ struct SMTLIBParser {
 
     if (!consumeExpected(')', ErrStr))
       return APInt();
-    if (!consumeExpected(')', ErrStr))
-      return APInt();
-    if (!consumeExpected(')', ErrStr))
-      return APInt();
 
     return APInt(Width, StringRef(NumBegin, NumEnd - NumBegin), 10);
+  }
+
+  APInt parseHexBitVector(std::string &ErrStr) {
+    ErrStr.clear();
+    const char *NumBegin = Begin;
+    while (Begin != End && ((*Begin >= '0' && *Begin <= '9') ||
+           (*Begin >= 'a' && *Begin <= 'f') ||
+           (*Begin >= 'A' && *Begin <= 'F')))
+      ++Begin;
+    const char *NumEnd = Begin;
+    unsigned Width = NumEnd - NumBegin;
+
+    return APInt(Width*4, StringRef(NumBegin, Width), 16);
+  }
+
+  APInt parseModel(std::string &ErrStr) {
+    APInt Res;
+
+    if (!consumeExpected('(', ErrStr))
+      return Res;
+    if (!consumeExpected('(', ErrStr))
+      return Res;
+    if (!consumeSExpr(ErrStr))
+      if (!consumeBvName(ErrStr))
+        return Res;
+    if (consumeExpected('#', ErrStr)) {
+      if (consumeExpected('x', ErrStr))
+        Res = parseHexBitVector(ErrStr);
+      else
+        Res = parseBinaryBitVector(ErrStr);
+    } else {
+      Res = parseDecimalBitVector(ErrStr);
+    }
+    if (!consumeExpected(')', ErrStr))
+      return Res;
+    if (!consumeExpected(')', ErrStr))
+      return Res;
+
+    return Res;
   }
 };
 
@@ -341,5 +390,5 @@ std::unique_ptr<SMTLIBSolver> souper::createSTPSolver(SolverProgram Prog,
 std::unique_ptr<SMTLIBSolver> souper::createZ3Solver(SolverProgram Prog,
                                                      bool Keep) {
   return std::unique_ptr<SMTLIBSolver>(
-      new ProcessSMTLIBSolver("Z3", Keep, Prog, false, {"-smt2", "-in"}));
+      new ProcessSMTLIBSolver("Z3", Keep, Prog, true, {"-smt2", "-in"}));
 }

--- a/test/Infer/bswap.ll
+++ b/test/Infer/bswap.ll
@@ -1,0 +1,16 @@
+; REQUIRES: solver solver-model
+
+; RUN: llvm-as -o %t1 %s
+; RUN: %souper %solver -souper-infer-iN %t1 > %t2
+; RUN: FileCheck %s -check-prefix=SUCCESS < %t2
+
+; SUCCESS: cand %0 873647531:i32
+
+; Function Attrs: nounwind readnone
+declare i32 @llvm.bswap.i32(i32) #0
+
+define i32 @foo(i32 %x) {
+entry:
+  %swap = call i32 @llvm.bswap.i32(i32 2882343476) ;input is 0xABCD1234
+  ret i32 %swap ;swapped result is 0x3412CDAB
+}

--- a/test/Infer/eggs.ll
+++ b/test/Infer/eggs.ll
@@ -1,7 +1,12 @@
-; REQUIRES: solver
+; REQUIRES: solver solver-model
 
-; RUN: llvm-as -o %t %s
-; RUN: %souper %solver -check %t
+; RUN: llvm-as -o %t1 %s
+; RUN: %souper %solver -souper-infer-iN %t1 > %t2
+; RUN: FileCheck -implicit-check-not=FIRST < %t2
+; RUN: FileCheck -implicit-check-not=SECOND < %t2
+
+; FIRST: cand %11 301:i10
+; SECOND: cand %11 721:i10
 
 ; A woman was carrying a large basket of eggs when a passer-by bumped her and
 ; she dropped the basket and all the eggs broke. The passer-by asked how many
@@ -28,22 +33,12 @@ cont3:
   %cmp4 = icmp eq i10 %rem4, 1
   br i1 %cmp4, label %cont4, label %out
 cont4:
-  %rem5 = urem i10 %x, 6
-  %cmp5 = icmp eq i10 %rem5, 1, !expected !1 ; redundant check
-  br i1 %cmp5, label %cont5, label %out
-cont5:
   %rem6 = urem i10 %x, 7
   %cmp6 = icmp eq i10 %rem6, 0
   br i1 %cmp6, label %cont6, label %out
 cont6:
-  %check1 = icmp eq i10 %x, 301
-  %check2 = icmp eq i10 %x, 721
-  %check = or i1 %check1, %check2, !expected !1 
-  %check3 = icmp eq i10 %x, 999, !expected !0
+  %res = add i10 %x, 0
   ret i10 %x
 out:
   ret i10 0
 }
-
-!0 = metadata !{ i1 0 }
-!1 = metadata !{ i1 1 }

--- a/test/Infer/eggs2.ll
+++ b/test/Infer/eggs2.ll
@@ -1,7 +1,10 @@
-; REQUIRES: solver
+; REQUIRES: solver solver-model
 
-; RUN: llvm-as -o %t %s
-; RUN: %souper %solver -check %t
+; RUN: llvm-as -o %t1 %s
+; RUN: %souper %solver -souper-infer-iN %t1 > %t2
+; RUN: FileCheck -check-prefix=SUCCESS < %t2
+
+; SUCCESS: cand %12 301:i10
 
 ; A woman was carrying a large basket of eggs when a passer-by bumped her and
 ; she dropped the basket and all the eggs broke. The passer-by asked how many
@@ -28,22 +31,15 @@ cont3:
   %cmp4 = icmp eq i10 %rem4, 1
   br i1 %cmp4, label %cont4, label %out
 cont4:
-  %rem5 = urem i10 %x, 6
-  %cmp5 = icmp eq i10 %rem5, 1, !expected !1 ; redundant check
-  br i1 %cmp5, label %cont5, label %out
-cont5:
   %rem6 = urem i10 %x, 7
   %cmp6 = icmp eq i10 %rem6, 0
   br i1 %cmp6, label %cont6, label %out
 cont6:
-  %check1 = icmp eq i10 %x, 301
-  %check2 = icmp eq i10 %x, 721
-  %check = or i1 %check1, %check2, !expected !1 
-  %check3 = icmp eq i10 %x, 999, !expected !0
+  %cmp7 = icmp ult i10 %x, 500
+  br i1 %cmp7, label %cont7, label %out
+cont7:
+  %res = add i10 %x, 0
   ret i10 %x
 out:
   ret i10 0
 }
-
-!0 = metadata !{ i1 0 }
-!1 = metadata !{ i1 1 }

--- a/test/Tool/intrinsic.ll
+++ b/test/Tool/intrinsic.ll
@@ -1,17 +1,7 @@
 ; REQUIRES: solver
 
-; RUN: llvm-as -o %t1 %s
-; RUN: %souper %t1 > %t2
-; RUN: %souper-check %solver -infer-rhs -print-replacement %t2 > %t3
-; RUN: FileCheck %s -check-prefix=SUCCESS < %t3
-; RUN: %parser-test -LHS < %t2
-; RUN: %parser-test < %t3
-; RUN: %souper-check %solver < %t3 | FileCheck -check-prefix=LGTM %s
-; RUN: %souper-check %solver -infer-rhs %t2 > %t4
-; RUN: cat %t2 %t4 | %souper-check %solver | FileCheck -check-prefix=LGTM %s
-
-; SUCCESS: RHS inferred successfully
-; LGTM: LGTM
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
 
 declare i64 @llvm.bswap.i64(i64) #0
 
@@ -19,6 +9,8 @@ define void @foo(i64 %x) {
 entry:
   %swap1 = call i64 @llvm.bswap.i64(i64 %x)
   %swap2 = call i64 @llvm.bswap.i64(i64 %swap1)
-  %cmp = icmp eq i64 %x, %swap2
+  %cmp = icmp eq i64 %x, %swap2, !expected !1
   ret void
 }
+
+!1 = metadata !{ i1 1 }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -29,3 +29,8 @@ config.substitutions.append(('%sclang', config.builddir + '/sclang'))
 if config.solver:
   config.available_features.add('solver')
   config.substitutions.append(('%solver', config.solver))
+  # Solvers with model support
+  for solver in ['z3', 'cvc4']:
+      if solver in config.solver:
+          config.available_features.add('solver-model')
+          break

--- a/unittests/Extractor/ExtractorTests.cpp
+++ b/unittests/Extractor/ExtractorTests.cpp
@@ -63,7 +63,7 @@ struct ExtractorTest : testing::Test {
           R.Mapping.RHS = I;
           std::unique_ptr<CandidateExpr> CE(
               new CandidateExpr(GetCandidateExprForReplacement(R.BPCs, R.PCs,
-                                                               R.Mapping)));
+                                                               R.Mapping, false)));
           CandExprs.emplace_back(std::move(CE));
         }
       }

--- a/utils/cache_infer.in
+++ b/utils/cache_infer.in
@@ -54,6 +54,7 @@ die $need_solver unless $solver;
 
 my $OPTS = "";
 $OPTS .= "-souper-infer-i1=false " if $ENV{"SOUPER_NO_INFER_I1"};
+$OPTS .= "-souper-infer-iN " if $ENV{"SOUPER_INFER_INT"};
 $OPTS .= "-souper-infer-nop " if $ENV{"SOUPER_INFER_NOP"};
 $OPTS .= "-souper-infer-unary " if $ENV{"SOUPER_INFER_UNARY"};
 

--- a/utils/sclang.in
+++ b/utils/sclang.in
@@ -107,6 +107,10 @@ if ($souper) {
         push @ARGV, ("-g", "-mllvm", "-souper-dynamic-profile");
     }
 
+    if ($ENV{"SOUPER_INFER_INT"}) {
+      push @ARGV, ("-mllvm", "-souper-infer-iN");
+    }
+
     if ($ENV{"SOUPER_IGNORE_SOLVER_ERRORS"}) {
         push @ARGV, ("-mllvm", "-souper-ignore-solver-errors");
     }


### PR DESCRIPTION
This patch teaches Souper to infer iN integers (``-souper-infer-iN`` option) using two solver queries without quantifiers. The first query is a SAT query ``LHS == constant`` asking for a model for ``constant`` whereas the second query is a ``LHS != constant_model`` query. If the result of the latter is UNSAT, we have synthesized a valid integer.

Note that STP doesn't support SMTLIBv2 option ``:produce-models``, so we have to use z3 or cvc4.