### PR TITLE
Enable running of valgrind from make check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,8 +250,13 @@ configure_file(
   ${CMAKE_BINARY_DIR}/test/lit.site.cfg
 )
 
+configure_file(
+  ${CMAKE_SOURCE_DIR}/utils/run_lit.in
+  ${CMAKE_BINARY_DIR}/run_lit
+)
+
 add_custom_target(check
-  COMMAND ${LLVM_BINDIR}/llvm-lit -sv ${CMAKE_BINARY_DIR}/test
+  COMMAND ${CMAKE_BINARY_DIR}/run_lit
   DEPENDS extractor_tests inst_tests parser-test parser_tests profileRuntime souper souper-check souperPass)
 
 find_program(GO_EXECUTABLE NAMES go DOC "go executable")

--- a/README
+++ b/README
@@ -35,6 +35,12 @@ Building Souper
 
 3. Run 'make' from the build directory.
 
+4. Optionally run 'make check' to run Souper's test suite. To run the test suite
+   under Valgrid, run 'make check LIT_ARGS="-v --vg --vg-leak"' instead. By
+   default the solver is also run under Valgrind. This can be disable by
+   by adding -vg-arg=--trace-children-skip=/usr/local/bin/stp to LIT_ARGS,
+   where /usr/local/bin/stp should be replaced by the appropriate solver path.
+
 Note that GCC 4.8 and earlier have a bug in handling multiline string
 literals. You should build Souper using GCC 4.9+ or Clang.
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -5,7 +5,7 @@ import sys
 
 config.name = 'Souper'
 config.suffixes = ['.c', '.ll', '.opt']
-config.test_format = lit.formats.ShTest()
+config.test_format = lit.formats.ShTest(True)
 config.test_source_root = os.path.dirname(__file__)
 config.test_exec_root = config.builddir + '/test'
 config.excludes = ['Inputs']

--- a/utils/run_lit.in
+++ b/utils/run_lit.in
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+# Copyright 2015 The Souper Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -z "$LIT_ARGS" ]; then
+  LIT_ARGS="-vs"
+fi
+
+${LLVM_BINDIR}/llvm-lit $LIT_ARGS ${CMAKE_BINARY_DIR}/test


### PR DESCRIPTION
Fixes #119 

I'm not following llvm's approach, as suggested by John; llvm achieves a similar effect through a hand-rolled Makefile in the test directory.