### PR TITLE
Fix iN synthesis test case execution

### DIFF
--- a/test/Infer/blockpc1.opt
+++ b/test/Infer/blockpc1.opt
@@ -1,0 +1,16 @@
+; REQUIRES: solver, solver-model
+
+; RUN: %souper-check %solver -infer-rhs -souper-infer-iN %s > %t
+; RUN: FileCheck %s -check-prefix=SUCCESS < %t
+
+; SUCCESS: result 10:i32
+
+%0 = block 2
+%1:i32 = var
+%2:i1 = eq 0:i32, %1
+blockpc %0 0 %2 0:i1
+blockpc %0 1 %2 1:i1
+%3:i32 = phi %0, 4:i32, 7:i32
+%4:i32 = phi %0, 6:i32, 3:i32
+%5:i32 = addnw %3, %4
+infer %5

--- a/test/Infer/blockpc2.opt
+++ b/test/Infer/blockpc2.opt
@@ -1,0 +1,17 @@
+; REQUIRES: solver, solver-model
+
+; RUN: %souper-check %solver -infer-rhs -souper-infer-iN %s > %t
+; RUN: FileCheck %s -check-prefix=SUCCESS < %t
+
+; SUCCESS: result 210:i32
+
+%0 = block 2
+%1:i32 = var
+%2:i1 = eq 0:i32, %1
+blockpc %0 0 %2 0:i1
+blockpc %0 1 %2 1:i1
+%3:i32 = phi %0, 4:i32, 7:i32
+%4:i32 = phi %0, 6:i32, 3:i32
+%5:i32 = addnw %3, %4
+%6:i32 = mulnsw 21:i32, %5
+infer %6

--- a/test/Infer/bswap.ll
+++ b/test/Infer/bswap.ll
@@ -1,4 +1,4 @@
-; REQUIRES: solver solver-model
+; REQUIRES: solver, solver-model
 
 ; RUN: llvm-as -o %t1 %s
 ; RUN: %souper %solver -souper-infer-iN %t1 > %t2

--- a/test/Infer/eggs.ll
+++ b/test/Infer/eggs.ll
@@ -1,9 +1,9 @@
-; REQUIRES: solver solver-model
+; REQUIRES: solver, solver-model
 
 ; RUN: llvm-as -o %t1 %s
 ; RUN: %souper %solver -souper-infer-iN %t1 > %t2
-; RUN: FileCheck -implicit-check-not=FIRST < %t2
-; RUN: FileCheck -implicit-check-not=SECOND < %t2
+; RUN: FileCheck %s -implicit-check-not=FIRST < %t2
+; RUN: FileCheck %s -implicit-check-not=SECOND < %t2
 
 ; FIRST: cand %11 301:i10
 ; SECOND: cand %11 721:i10

--- a/test/Infer/eggs2.ll
+++ b/test/Infer/eggs2.ll
@@ -1,8 +1,8 @@
-; REQUIRES: solver solver-model
+; REQUIRES: solver, solver-model
 
 ; RUN: llvm-as -o %t1 %s
 ; RUN: %souper %solver -souper-infer-iN %t1 > %t2
-; RUN: FileCheck -check-prefix=SUCCESS < %t2
+; RUN: FileCheck %s -check-prefix=SUCCESS < %t2
 
 ; SUCCESS: cand %12 301:i10
 

--- a/test/Infer/subnsw.opt
+++ b/test/Infer/subnsw.opt
@@ -1,0 +1,15 @@
+; REQUIRES: solver, solver-model
+
+; RUN: %souper-check %solver -infer-rhs -souper-infer-iN %s > %t
+; RUN: FileCheck %s -check-prefix=SUCCESS < %t
+
+; SUCCESS: result 0:i32
+
+%0:i32 = var
+%1:i32 = var
+%2:i1 = eq %0, %1
+pc %2 1:i1
+%3:i32 = addnsw 1:i32, %0
+%4:i32 = addnsw 1:i32, %1
+%5:i32 = subnsw %3, %4
+infer %5


### PR DESCRIPTION
The iN synthesis test cases that were tested separately were not executed during ``make check``. The ``REQUIRES:`` directive requires the features to be separated by a comma. Also, ``FileCheck`` was missing the ``check-file``. 