### PR TITLE
Redirect diagnostic output of solver to /dev/null

### DIFF
--- a/include/souper/SMTLIB2/Solver.h
+++ b/include/souper/SMTLIB2/Solver.h
@@ -26,7 +26,8 @@ namespace souper {
 
 typedef std::function<
     int(const std::vector<std::string> &Args, llvm::StringRef RedirectIn,
-        llvm::StringRef RedirectOut, unsigned Timeout)> SolverProgram;
+        llvm::StringRef RedirectOut, llvm::StringRef RedirectErr,
+        unsigned Timeout)> SolverProgram;
 
 class SMTLIBSolver {
 public:


### PR DESCRIPTION
First attempt at doing something else with the diagnostic output produced by a solver (related to Issue #149).

I considered not redirecting stderr at all. For ```makeInternalSolverProgram``` this is easily doable. However for ```makeExternalSolverProgram``` this seems impossible, as ```ExecuteAndWait``` only accepts file names as targets for redirection and not file descriptors, where a nullptr target implies redirection to /dev/null.