### PR TITLE
Added preconditions to the UBInstrs collected through blockpc

### DIFF
--- a/test/Tool/blockpc-invalid-3.opt
+++ b/test/Tool/blockpc-invalid-3.opt
@@ -1,0 +1,21 @@
+; REQUIRES: solver
+
+; RUN: %souper-check %solver -print-counterexample=false %s > %t 2>&1
+; RUN: FileCheck %s < %t
+
+; CHECK: Invalid
+%0 = block 3
+%1:i32 = var
+%2:i1 = slt 0:i32, %1
+blockpc %0 0 %2 1:i1
+%3:i32 = subnsw 2147483647:i32, %1
+%4:i32 = var
+%5:i1 = slt %3, %4
+blockpc %0 0 %5 1:i1
+%6:i1 = slt %1, 0:i32
+blockpc %0 1 %6 1:i1
+%7:i32 = subnsw 2147483648:i32, %1
+%8:i1 = slt %4, %7
+blockpc %0 1 %8 1:i1
+%9:i32 = phi %0, 1:i32, 1:i32, 0:i32
+cand %9 0:i32

--- a/test/Tool/blockpc-invalid-4.opt
+++ b/test/Tool/blockpc-invalid-4.opt
@@ -1,0 +1,49 @@
+; REQUIRES: solver
+
+; RUN: %souper-check %solver -print-counterexample=false %s > %t 2>&1
+; RUN: FileCheck %s < %t
+
+; CHECK: Invalid
+%0 = block 5
+%1:i64 = var
+%2:i1 = eq 18446744073709551615:i64, %1
+blockpc %0 0 %2 0:i1
+%3 = block 2
+%4:i32 = var
+%5:i1 = ult %4, 65:i32
+blockpc %3 0 %5 0:i1
+%6:i32 = and 63:i32, %4
+%7:i1 = eq 0:i32, %6
+blockpc %3 0 %7 0:i1
+blockpc %3 1 %5 0:i1
+%8 = block 2
+%9:i64 = var
+%10:i32 = subnsw 64:i32, %6
+%11:i64 = zext %10
+%12:i64 = phi %3, %11, 0:i64
+%13:i64 = shl %9, %12
+%14:i1 = eq 18446744073709551615:i64, %13
+blockpc %8 0 %14 0:i1
+blockpc %0 3 %5 1:i1
+%15:i64 = var
+%16:i32 = sub 64:i32, %4
+%17:i64 = zext %16
+%18:i64 = shl %15, %17
+%19:i1 = eq 18446744073709551615:i64, %18
+blockpc %0 3 %19 0:i1
+blockpc %0 4 %5 1:i1
+%20:i32 = var
+%21:i64 = xor 18446744073709551615:i64, %1
+%22:i64 = ctlz %21
+%23:i32 = trunc %22
+%24:i32 = add %20, %23
+%25:i64 = xor 18446744073709551615:i64, %13
+%26:i64 = ctlz %25
+%27:i32 = trunc %26
+%28:i32 = phi %8, %27, 64:i32
+%29:i64 = xor 18446744073709551615:i64, %18
+%30:i64 = ctlz %29
+%31:i32 = trunc %30
+%32:i32 = phi %0, %24, %20, %28, %31, 64:i32
+infer %32
+result %10

--- a/test/Tool/blockpc-invalid-5.opt
+++ b/test/Tool/blockpc-invalid-5.opt
@@ -1,0 +1,56 @@
+; REQUIRES: solver
+
+; RUN: %souper-check %solver -print-counterexample=false %s > %t 2>&1
+; RUN: FileCheck %s < %t
+
+; CHECK: Invalid
+%0 = block 5
+%1:i64 = var
+%2:i1 = eq 18446744073709551615:i64, %1
+blockpc %0 0 %2 0:i1
+%3 = block 2
+%4:i32 = var
+%5:i1 = ult %4, 65:i32
+blockpc %3 0 %5 0:i1
+%6:i32 = and 63:i32, %4
+%7:i1 = eq 0:i32, %6
+blockpc %3 0 %7 0:i1
+blockpc %3 1 %5 0:i1
+%8 = block 2
+%9:i64 = var
+%10:i32 = subnsw 64:i32, %6
+%11:i64 = zext %10
+%12:i64 = phi %3, %11, 0:i64
+%13:i64 = shl %9, %12
+%14:i1 = eq 18446744073709551615:i64, %13
+blockpc %8 0 %14 0:i1
+blockpc %0 2 %5 1:i1
+%15:i64 = var
+%16:i32 = sub 64:i32, %4
+%17:i64 = zext %16
+%18:i64 = shl %15, %17
+%19:i1 = eq 18446744073709551615:i64, %18
+blockpc %0 2 %19 0:i1
+blockpc %0 3 %5 1:i1
+%20 = block 2
+blockpc %20 0 %2 1:i1
+%21:i32 = phi %3, %6, 64:i32
+%22:i64 = xor 18446744073709551615:i64, %13
+%23:i64 = ctlz %22
+%24:i32 = trunc %23
+%25:i32 = phi %8, %24, 64:i32
+%26:i1 = eq %21, %25
+blockpc %20 1 %26 1:i1
+%27:i32 = var
+%28:i64 = xor 18446744073709551615:i64, %1
+%29:i64 = ctlz %28
+%30:i32 = trunc %29
+%31:i32 = add %27, %30
+%32:i64 = xor 18446744073709551615:i64, %18
+%33:i64 = ctlz %32
+%34:i32 = trunc %33
+%35:i32 = add 64:i32, %27
+%36:i32 = phi %20, %35, %21
+%37:i32 = phi %0, %31, %25, %34, 64:i32, %36
+infer %37
+result %4


### PR DESCRIPTION
In the original blockpc commit, we actually didn't consider
UB instructions on blockpc(s), because EB.getUBInstCondition was
invoked before blockpcs were processed. The problem was exposed
by the commit 22989c0 ("Handle instruction UB on the RHS correctly"),
where the order of getUBInstCondition and getBlockPCs were reversed.

Consequently, souper incorrectly produced the following smt query (simplified)
for the bug-induction opt file:

  (and (blockpcs ...) (and (ub-expr on "subnsw 2147483647:i32, %1")
                           (ub-expr on "subnsw 2147483648:i32, %1")))

This is wrong because those two instructions are conditional: they can
be considered only if the relevant blockpcs are true. So, the correct
form should be:

  (and (blockpcs ...) (and (relevant blockpc => ub-expr on "subnsw 2147483647:i32, %1")
                            ...))

where "=>" stands for "imply".

This patch fixed this issue (issue #154)