### PR TITLE
Fix signs.opt specification encoding

### DIFF
--- a/test/Infer/signs.opt
+++ b/test/Infer/signs.opt
@@ -9,14 +9,14 @@
 %2:i32 = var
 %3:i1 = slt %2, 0:i32
 %4:i1 = and %1, %3
-pc %4 0:i1
 %5:i1 = slt 4294967295:i32, %2
 %6:i1 = slt %0, 0:i32
 %7:i1 = and %5, %6
-infer %7
+%8:i1 = xor %4, %7
+infer %8
 
 ; (a^b) < 0;
 
-%8:i32 = xor %0, %2
-%9:i1 = slt %8, 0
-result %9
+%9:i32 = xor %0, %2
+%10:i1 = slt %9, 0
+result %10


### PR DESCRIPTION
The souper encoding of ``(a<0 && b>=0) || (a>=0 && b<0)`` was not correct.