### PR TITLE
Make UB exploitation optional (default=true)

### DIFF
--- a/test/Solver/add-nsw-no-ub.ll
+++ b/test/Solver/add-nsw-no-ub.ll
@@ -1,0 +1,12 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -souper-exploit-ub=false -check %t
+
+define i32 @foo(i32 %x) {
+entry:
+  %add = add nsw i32 %x, 1
+  %cmp = icmp sgt i32 %add, %x
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}

--- a/utils/sclang.in
+++ b/utils/sclang.in
@@ -91,6 +91,10 @@ if ($souper) {
         push @ARGV, ("-mllvm", "-souper-debug");
     }
 
+    if ($ENV{"SOUPER_NO_EXPLOIT_UB"}) {
+        push @ARGV, ("-mllvm", "-souper-exploit-ub=false");
+    }
+
     if (!$ENV{"SOUPER_NO_EXTERNAL_CACHE"}) {
         push @ARGV, ("-mllvm", "-souper-external-cache");
     }


### PR DESCRIPTION
Optionally turn off UB exploitation via command line ``-souper-exploit-ub``. Default is ``true``.