### PR TITLE
Skip blockpc(s) where the block's phis are not relevant

### DIFF
--- a/include/souper/Inst/Inst.h
+++ b/include/souper/Inst/Inst.h
@@ -25,10 +25,12 @@
 
 namespace souper {
 
+struct Inst;
 struct Block {
   std::string Name;
   unsigned Preds;
   unsigned Number;
+  std::vector<Inst *> Phis;
 };
 
 struct Inst : llvm::FoldingSetNode {

--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -583,21 +583,56 @@ std::vector<Inst *> AddBlockPCSets(const BlockPCs &BPCs, InstClasses &Vars) {
   return BPCSets;
 }
 
+bool HasRelevantPhi(const Block *B, llvm::DenseMap<const Block *, bool> SeenBlocks,
+                    InstMapping Cand) {
+  auto Iter = SeenBlocks.find(B);
+  if (Iter != SeenBlocks.end())
+    return Iter->second;
+
+  bool RV = false;
+  for (auto &Phi : B->Phis) {
+    InstClasses PhiVars;
+    llvm::DenseSet<Inst *> SeenInsts;
+    auto PhiLeader = AddVarSet(PhiVars.member_end(), PhiVars, SeenInsts, Phi);
+    if (PhiLeader == PhiVars.member_end())
+      continue;
+    SeenInsts.clear();
+    auto Leader = AddVarSet(PhiVars.member_end(), PhiVars, SeenInsts, Cand.LHS);
+    if (PhiVars.findLeader(*PhiLeader) == Leader) {
+      RV = true;
+      break;
+    }
+  }
+  SeenBlocks[B] = RV;
+  return RV;
+}
+
 // Return vectors of relevant BlockPCs and PCs for a candidate, namely those
 // whose variable sets are in the same equivalence class as the candidate's.
 std::tuple<BlockPCs, std::vector<InstMapping>> GetRelevantPCs(
     const BlockPCs &BPCs, const std::vector<InstMapping> &PCs,
     const std::vector<Inst *> &BPCSets, const std::vector<Inst *> &PCSets,
-    InstClasses Vars, InstMapping Cand) {
+    InstClasses Vars, InstClasses BPCVars, InstMapping Cand) {
 
   llvm::DenseSet<Inst *> SeenInsts;
-  auto Leader = AddVarSet(Vars.member_end(), Vars, SeenInsts, Cand.LHS);
+  auto BPCLeader = AddVarSet(BPCVars.member_end(),
+                             BPCVars, SeenInsts, Cand.LHS);
 
   BlockPCs RelevantBPCs;
+  llvm::DenseMap<const Block *, bool> SeenBlocks;
+  // In addition to making sure BPC's LHS and Cand.LHS are in the same
+  // equivalence class, we also need to check whether any Phi of the block
+  // and Cand.LHS are in the same equivalence class. If no Phi instructions
+  // relate to Cand.LHS, then the Phi instructions won't be printed out.
+  // Consequently, we will end up with insufficeint souper IR.
   for (unsigned i = 0; i != BPCs.size(); ++i) {
-    if (BPCSets[i] != 0 && Vars.findLeader(BPCSets[i]) == Leader)
+    if (BPCSets[i] != 0 && BPCVars.findLeader(BPCSets[i]) == BPCLeader &&
+        HasRelevantPhi(BPCs[i].B, SeenBlocks, Cand))
       RelevantBPCs.emplace_back(BPCs[i]);
   }
+
+  SeenInsts.clear();
+  auto Leader = AddVarSet(Vars.member_end(), Vars, SeenInsts, Cand.LHS);
 
   std::vector<InstMapping> RelevantPCs;
   for (unsigned i = 0; i != PCs.size(); ++i) {
@@ -629,7 +664,8 @@ void ExtractExprCandidates(Function &F, const LoopInfo *LI,
 
       for (auto &R : BCS->Replacements) {
         std::tie(R.BPCs, R.PCs) = 
-          GetRelevantPCs(BCS->BPCs, BCS->PCs, BPCSets, PCSets, Vars, R.Mapping);
+          GetRelevantPCs(BCS->BPCs, BCS->PCs, BPCSets,
+                         PCSets, Vars, BPCVars, R.Mapping);
       }
 
       Result.Blocks.emplace_back(std::move(BCS));

--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -422,6 +422,7 @@ Inst *InstContext::getPhi(Block *B, const std::vector<Inst *> &Ops) {
   N->B = B;
   N->Ops = Ops;
   InstSet.InsertNode(N, IP);
+  B->Phis.emplace_back(N);
   return N;
 }
 

--- a/test/Extractor/blockpc3.ll
+++ b/test/Extractor/blockpc3.ll
@@ -1,0 +1,62 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+@x1 = common global i32 0, align 4
+@x0 = common global i32 0, align 4
+@x5 = common global i32 0, align 4
+@x2 = common global i32 0, align 4
+@x3 = common global i32 0, align 4
+@x4 = common global i32 0, align 4
+@str = private unnamed_addr constant [2 x i8] c"x\00", align 1
+
+define i32 @main() {
+  %1 = load i32* @x1
+  %2 = icmp slt i32 %1, 1
+  br i1 %2, label %._crit_edge, label %3
+
+._crit_edge:                                      ; preds = %0
+  %.pre = load i32* @x2
+  br label %14
+
+; <label>:3                                       ; preds = %0
+  %4 = load i32* @x0
+  %5 = icmp sgt i32 %4, 1
+  %6 = zext i1 %5 to i32
+  br i1 %5, label %10, label %7
+
+; <label>:7                                       ; preds = %3
+  %8 = icmp sgt i32 %4, 0
+  %9 = zext i1 %8 to i32
+  br label %10
+
+; <label>:10                                      ; preds = %7, %3
+  %11 = phi i32 [ %9, %7 ], [ %6, %3 ]
+  store i32 %11, i32* @x5
+  store i32 %11, i32* @x2
+  %12 = icmp slt i32 %1, %11, !expected !0
+  br i1 %12, label %14, label %13
+
+; <label>:13                                      ; preds = %10
+  store i32 0, i32* @x3
+  br label %14
+
+; <label>:14                                      ; preds = %13, %10, %._crit_edge
+  %15 = phi i32 [ %11, %10 ], [ %.pre, %._crit_edge ], [ %11, %13 ]
+  store i32 %15, i32* @x4
+  %16 = icmp eq i32 %1, 0
+  br i1 %16, label %17, label %18
+
+; <label>:17                                      ; preds = %14
+  %puts = tail call i32 @puts(i8* getelementptr inbounds ([2 x i8]* @str, i64 0, i64 0))
+  br label %18
+
+; <label>:18                                      ; preds = %17, %14
+  ret i32 0
+}
+
+declare i32 @puts(i8*)
+
+!0 = metadata !{ i1 0 }
+


### PR DESCRIPTION
When we generate relevant blockpc(s), we have to filter out
those where the block's phi instructions are not relevant to
the replacement candicate. Let's look at the following (simplified)
example:

; <label>:10                                      ; preds = %3, %7
  %11 = phi i32 [ %9, %7 ], [ %6, %3 ]
  store i32 %11, i32* @x5, align 4, !tbaa !1
  br i1 false, label %13, label %12

; <label>:12                                      ; preds = %10
  store i32 0, i32* @x3, align 4, !tbaa !1
  br label %13

; <label>:13                                      ; preds = %._crit_edge, %10, %12
  %14 = phi i32 [ %11, %10 ], [ %.pre, %._crit_edge ], [ %11, %12 ]
  store i32 %14, i32* @x4, align 4, !tbaa !1
  %16 = icmp eq i32 %1, 0

Previously, when we generate replacement candidate for instruction %16,
we will generate blockpc coming from [%11, %12], e.g.,

...
%10:i1 = slt %1, %9
blockpc %3 2 %10 0:i1
%11:i1 = eq 0:i32, %1
cand %11 0:i1

because %10 relates to %11 (they have %1 in common). However, it's bad
because the phi node is missing. Consequently, when we generate KLEE expressions,
blockpc %3 won't be touched because it can't be reached from any phi instruction,
and hence we will generate insufficient queries and mis-optimize the given code.

This patch fixed this issue (#166).