### PR TITLE
fix a use-of-unitialized variable bug that is triggered by cold external cache

### DIFF
--- a/lib/Extractor/Solver.cpp
+++ b/lib/Extractor/Solver.cpp
@@ -251,6 +251,7 @@ public:
     } else {
       ++ExternalMisses;
       if (NoInfer) {
+        RHS = 0;
         KV->hSet(LHSStr, "result", "");
         return std::error_code();
       }


### PR DESCRIPTION
and a command line such as this:

souper  -stp-path=/usr/local/bin/stp -souper-no-infer -souper-external-cache 9gLRvwcI9i.bc