### PR TITLE
Don't turn-off UB constraints on the RHS

### DIFF
--- a/lib/Extractor/KLEEBuilder.cpp
+++ b/lib/Extractor/KLEEBuilder.cpp
@@ -918,14 +918,14 @@ CandidateExpr souper::GetCandidateExprForReplacement(
   }
   // Get UB constraints of LHS and (B)PCs
   ref<Expr> LHSPCsUB = klee::ConstantExpr::create(1, Expr::Bool);
+  // Turning-off UB exploitation turns off UB on the LHS only
   if (ExploitUB)
     LHSPCsUB = EB.getUBInstCondition();
   // Build RHS
   ref<Expr> RHS = EB.get(Mapping.RHS);
   // Get all UB constraints (LHS && (B)PCs && RHS)
   ref<Expr> UB = klee::ConstantExpr::create(1, Expr::Bool);
-  if (ExploitUB)
-    UB = EB.getUBInstCondition();
+  UB = EB.getUBInstCondition();
 
   ref<Expr> Cons;
   if (Negate) // (LHS != RHS)

--- a/test/Infer/ub-rhs5.opt
+++ b/test/Infer/ub-rhs5.opt
@@ -1,0 +1,10 @@
+; REQUIRES: solver
+; RUN: %souper-check %solver %s -souper-exploit-ub=false | FileCheck %s
+; CHECK: Invalid
+
+%0:i32 = var
+%1:i32 = xor %0, %0
+infer %1
+
+%2:i32 = lshr %0, %0
+result %2


### PR DESCRIPTION
The pull request #165 was incomplete, it disabled UB on the RHS
in the -souper-exploit-ub=false mode, resulting in unsound reasoning
