### PR TITLE
Handle llvm.assume (B)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ execute_process(
 set(LLVM_CXXFLAGS "${LLVM_CXXFLAGS} -fno-exceptions -fno-rtti -DLLVM_ENABLE_STATS=true")
 
 execute_process(
-  COMMAND ${LLVM_CONFIG_EXECUTABLE} --libs bitreader bitwriter instrumentation ipo irreader linker mc mcparser objcarcopts option profiledata scalaropts transformutils
+  COMMAND ${LLVM_CONFIG_EXECUTABLE} --libs bitreader bitwriter instrumentation ipo irreader linker mc mcparser objcarcopts option profiledata scalaropts transformutils target
   OUTPUT_VARIABLE LLVM_LIBS
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )


### PR DESCRIPTION
I think this is a proper handling of llvm.assume. Ignoring any replacement that seeks to prove something already known doesn't simplify assumes in my tests. I originally had the removal of the replacement in Pass.cpp after the solver was invoked, so the replacement could be compared against the path constraint's value. However, if that test failed for a PC with a const RHS, it would prove an internal inconsistency, and thus the earlier check should speed up souper while retaining useful candidates.