### PR TITLE
LLVM's local identifier can't be just a dot

### DIFF
--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -116,8 +116,7 @@ FoundChar:
       const char *NameBegin = Begin;
       while (Begin != End && ((*Begin >= '0' && *Begin <= '9') ||
                               (*Begin >= 'A' && *Begin <= 'Z') ||
-                              (*Begin >= 'a' && *Begin <= 'z') ||
-                              (*Begin == '.'))) {
+                              (*Begin >= 'a' && *Begin <= 'z'))) {
         ++Begin;
       }
       if (Begin == NameBegin) {


### PR DESCRIPTION
Don't allow '%.' as a LLVM local identifier