### PR TITLE
add a new option for dynamic profiling of all sites that souper might

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(Souper)
 
+set(CMAKE_MACOSX_RPATH NEW)
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING
       "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
@@ -196,6 +198,19 @@ add_library(souperPass SHARED
   lib/Pass/Pass.cpp
 )
 
+add_library(souperPassProfileAll SHARED
+  ${KLEE_EXPR_FILES}
+  ${SOUPER_EXTRACTOR_FILES}
+  ${SOUPER_INST_FILES}
+  ${SOUPER_KVSTORE_FILES}
+  ${SOUPER_PARSER_FILES}
+  ${SOUPER_SMTLIB2_FILES}
+  ${SOUPER_TOOL_FILES}
+  ${SOUPER_INFER_FILES}
+  lib/Pass/Pass.cpp
+)
+target_compile_definitions(souperPassProfileAll PRIVATE DYNAMIC_PROFILE_ALL=1)
+
 add_executable(clang-souper
   tools/clang-souper.cpp
 )
@@ -232,7 +247,7 @@ add_executable(parser_tests
   unittests/Parser/ParserTests.cpp
 )
 
-set_target_properties(souper internal-solver-test lexer-test parser-test souper-check souperExtractor souperInfer souperInst souperKVStore souperParser souperSMTLIB2 souperTool souperPass kleeExpr
+set_target_properties(souper internal-solver-test lexer-test parser-test souper-check souperExtractor souperInfer souperInst souperKVStore souperParser souperSMTLIB2 souperTool souperPass souperPassProfileAll kleeExpr
   PROPERTIES COMPILE_FLAGS "${LLVM_CXXFLAGS}")
 set_target_properties(souperClangTool clang-souper
   PROPERTIES COMPILE_FLAGS "${CLANG_CXXFLAGS} ${LLVM_CXXFLAGS}")
@@ -249,6 +264,7 @@ target_link_libraries(souperParser souperInst ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperSMTLIB2 ${LLVM_LIBS} ${LLVM_LDFLAGS})
 target_link_libraries(souperTool souperExtractor souperSMTLIB2)
 target_link_libraries(souperPass ${PASS_LDFLAGS} ${HIREDIS_LIBRARY})
+target_link_libraries(souperPassProfileAll ${PASS_LDFLAGS} ${HIREDIS_LIBRARY})
 target_link_libraries(souper souperExtractor souperKVStore souperParser souperSMTLIB2 souperTool kleeExpr ${HIREDIS_LIBRARY})
 target_link_libraries(internal-solver-test souperSMTLIB2)
 target_link_libraries(lexer-test souperParser)
@@ -274,7 +290,7 @@ configure_file(
 
 add_custom_target(check
   COMMAND ${CMAKE_BINARY_DIR}/run_lit
-  DEPENDS extractor_tests inst_tests parser-test parser_tests profileRuntime souper souper-check souperPass)
+  DEPENDS extractor_tests inst_tests parser-test parser_tests profileRuntime souper souper-check souperPass souperPassProfileAll)
 
 find_program(GO_EXECUTABLE NAMES go DOC "go executable")
 if(NOT GO_EXECUTABLE STREQUAL "GO_EXECUTABLE-NOTFOUND")
@@ -294,6 +310,7 @@ add_library(profileRuntime STATIC
   runtime/souperPassProfile.c)
 
 set(SOUPER_PASS ${CMAKE_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}souperPass${CMAKE_SHARED_LIBRARY_SUFFIX})
+set(SOUPER_PASS_PROFILE_ALL ${CMAKE_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}souperPassProfileAll${CMAKE_SHARED_LIBRARY_SUFFIX})
 set(PROFILE_LIBRARY ${CMAKE_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}profileRuntime${CMAKE_STATIC_LIBRARY_SUFFIX})
 configure_file(${CMAKE_SOURCE_DIR}/utils/sclang.in ${CMAKE_BINARY_DIR}/sclang @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/utils/sclang.in ${CMAKE_BINARY_DIR}/sclang++ @ONLY)

--- a/utils/sclang.in
+++ b/utils/sclang.in
@@ -83,10 +83,15 @@ $souper = 0 unless compiling();
 if ($souper) {
     push @ARGV, (
         "-Xclang", "-load",
-        "-Xclang", "@SOUPER_PASS@",
         "-mllvm", $solver,
         "-mllvm", "-solver-timeout=15",
     );
+
+    if (exists $ENV{"SOUPER_DYNAMIC_PROFILE_ALL"}) {
+	push @ARGV, ("-Xclang", "@SOUPER_PASS_PROFILE_ALL@");
+    } else {
+	push @ARGV, ("-Xclang", "@SOUPER_PASS@");
+    }
 
     if (exists $ENV{"SOUPER_DEBUG"}) {
         push @ARGV, ("-mllvm", "-souper-debug");
@@ -120,7 +125,8 @@ if ($souper) {
         push @ARGV, ("-mllvm", "-souper-static-profile");
     }
 
-    if (exists $ENV{"SOUPER_DYNAMIC_PROFILE"}) {
+    if (exists $ENV{"SOUPER_DYNAMIC_PROFILE"} ||
+	exists $ENV{"SOUPER_DYNAMIC_PROFILE_ALL"}) {
         push @ARGV, ("-g", "-mllvm", "-souper-dynamic-profile");
     }
 
@@ -140,7 +146,8 @@ if ($souper) {
     }
 }
 
-if (exists $ENV{"SOUPER_DYNAMIC_PROFILE"} && linkp()) {
+if ((exists $ENV{"SOUPER_DYNAMIC_PROFILE"} ||
+     exists $ENV{"SOUPER_DYNAMIC_PROFILE_ALL"}) && linkp()) {
     push @ARGV, ("@PROFILE_LIBRARY@", "@HIREDIS_LIBRARY@");
 }
 


### PR DESCRIPTION
optimize, not just the ones that it has been able to optimize. this is
useful because it permits us to find the highest profile sites and
then run expensive synthesis only on those, instead of doing synthesis
first.

this profile-all mode needs to run last: it can't run as a peephole
pass.  unfortunately it isn't possible to make a single pass that is
scheduled either as a peephole or running last, so this patch compiles
two versions of the pass and then sclang chooses the right one

also, it turns out that running profile code from an LLVM function
pass was incorrect and only happened to work: it is illegal to add new
functions from a function pass. so turn the function pass into a
module pass.

finally, fix a different bug in the profile instrumentation where we
had failed to put the atomic increment below any phi nodes that happen
to be there.