### PR TITLE
improvements for support tools:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,5 +316,6 @@ configure_file(${CMAKE_SOURCE_DIR}/utils/sclang.in ${CMAKE_BINARY_DIR}/sclang @O
 configure_file(${CMAKE_SOURCE_DIR}/utils/sclang.in ${CMAKE_BINARY_DIR}/sclang++ @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/utils/reduce.in ${CMAKE_BINARY_DIR}/reduce @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/utils/cache_dump.in ${CMAKE_BINARY_DIR}/cache_dump @ONLY)
+configure_file(${CMAKE_SOURCE_DIR}/utils/cache_import.in ${CMAKE_BINARY_DIR}/cache_import @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/utils/cache_infer.in ${CMAKE_BINARY_DIR}/cache_infer @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/utils/souper2llvm.in ${CMAKE_BINARY_DIR}/souper2llvm @ONLY)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -13,6 +13,7 @@ config.excludes = ['Inputs']
 config.substitutions.append((r"\bFileCheck\b", config.llvm_bindir + '/FileCheck'))
 config.substitutions.append((r"\bclang\b", config.llvm_bindir + '/clang'))
 config.substitutions.append((r"\bllvm-as\b", config.llvm_bindir + '/llvm-as'))
+config.substitutions.append((r"\bllvm-dis\b", config.llvm_bindir + '/llvm-dis'))
 config.substitutions.append((r"\bopt\b", config.llvm_bindir + '/opt'))
 
 config.substitutions.append(('%builddir', config.builddir))

--- a/utils/cache_dump.in
+++ b/utils/cache_dump.in
@@ -40,12 +40,13 @@ Options:
   -merge       Merge optimizations that differ only in bitwidths and constants
   -noopts      Dump not-optimizations instead of optimizations
   -parse       Ensure that each LHS in the cache parses as Souper
-  -sort=size|sprofile|dprofile
+  -sort=size|sprofile|dprofile|combined
                Sort optimizations by increasing size (default), decreasing
                static profile count, or descreasing dynamic profile count
   -raw         Dump all keys and values and exit, ignoring all other options
   -reduce      Attempt to reduce the size of each optimization
   -triage      Attempt to avoid reporting optimizations that LLVM can do
+  -weaken      Weaken dataflow facts
   -verbose
   -verify      Verify each optimization
 END
@@ -59,6 +60,7 @@ my $REDUCE = 0;
 my $MERGE = 0;
 my $PARSE = 0;
 my $TRIAGE = 0;
+my $WEAKEN = 0;
 my $VERBOSE = 0;
 my $VERIFY = 0;
 GetOptions(
@@ -69,10 +71,12 @@ GetOptions(
     "raw"  => \$RAW,
     "reduce" => \$REDUCE,
     "triage" => \$TRIAGE,
+    "weaken" => \$WEAKEN,
     "verbose" => \$VERBOSE,
     "verify" => \$VERIFY,
     ) or usage();
-usage() unless ($SORT eq "size" || $SORT eq "sprofile" || $SORT eq "dprofile");
+usage() unless ($SORT eq "size" || $SORT eq "sprofile" || $SORT eq "dprofile" ||
+    $SORT eq "combined");
 
 my $noopt_count=0;
 my %values;
@@ -85,6 +89,11 @@ my %toprint;
 my $r = Redis->new();
 $r->ping || die "no server?";
 my @all_keys = $r->keys('*');
+
+foreach my $opt (@all_keys) {
+    $sprofiles{$opt} = 0;
+    $dprofiles{$opt} = 0;
+}
 
 if ($RAW) {
     foreach my $opt (sort @all_keys) {
@@ -131,6 +140,31 @@ sub parse ($$) {
     }
 }
 
+my $need_solver = <<END;
+$0 requires the SOUPER_SOLVER environment variable to be defined, e.g. as
+-stp-path=/path/to/stp
+END
+
+sub checkstr ($) {
+    (my $s) = @_;
+    my $solver = $ENV{"SOUPER_SOLVER"};
+    die $need_solver unless $solver;
+    (my $fh, my $tmpfn) = File::Temp::tempfile();
+    print $fh $s;
+    $fh->flush();
+    open INF, "${check} ${solver} < $tmpfn 2>/dev/null |";
+    my $output = "";
+    while (my $line = <INF>) {
+        chomp $line;
+        $output .= $line;
+    }
+    close INF;
+    close $fh;
+    unlink $tmpfn;
+    return 1 if ($output =~ "LGTM");
+    return 0;
+}
+
 sub add_sprofile($$) {
     (my $opt, my $href) = @_;
     my %h = %{$href};
@@ -154,10 +188,17 @@ sub add_dprofile($$) {
 }
 
 my $xcnt = 0;
+my $tagged = 0;
+my $untagged = 0;
 foreach my $opt (@all_keys) {
     # last if $xcnt++ > 2500;
     my %h = $r->hgetall($opt);
     my $result = $h{"result"};
+    if (defined $h{"cache-infer-tag"}) {
+	$tagged++;
+    } else { 
+	$untagged++;
+    }
     if (defined($result)) {
         parse($opt, $result) if $PARSE;
     } else {
@@ -283,6 +324,37 @@ if ($REDUCE) {
     # die unless ($tprofile == total_profile_count());
 }
 
+sub grab_output($) {
+    (my $cmd) = @_;
+    open INF, $cmd or die;
+    my @llvm = ();
+    while (my $line = <INF>) {
+        push @llvm, $line;
+    }
+    close INF;
+    return \@llvm;
+}
+
+sub count_insns($) {
+    (my $lref) = @_;
+    my @l = @{$lref};
+    my $in = 0;
+    my $count = 0;
+    foreach my $line (@l) {
+        if ($line =~ /foo0:/) {
+            $in = 1;
+            next;
+        }
+        if ($line =~ /ret /) {
+            $in = 0;
+            next;
+        }
+        $count++ if $in;
+    }
+    # print "$count lines\n";
+    return $count;
+}
+
 if ($TRIAGE) {
     print "; Triaging\n";
 
@@ -292,22 +364,111 @@ if ($TRIAGE) {
         (my $fh1, my $fn1) = File::Temp::tempfile();
         print $fh1 $opt;
         close $fh1;
-        open INF, "$triager < $fn1 | $llvmas | $llvmopt -O3 | $llvmdis |" or die;
-        my $good = 0;
-        my $bogus = 1;
-        my $llvm = "";
-        while (my $line = <INF>) {
-            $bogus = 0 if ($line =~ /dummy2/);
-            $good = 1 if ($line =~ /dummy2w = atomicrmw/);
-            $llvm .= $line;
-        }
-        close INF;
-        print "oops: '$opt' turned into bogus LLVM: '$llvm'\n\n" if $bogus;
-        remove($opt) unless $good && !$bogus;
+        my @llvm1 = @{grab_output("$triager < $fn1 | $llvmas | $llvmdis |")};
+        my @llvm2 = @{grab_output("$triager < $fn1 | $llvmas | $llvmopt -O3 | $llvmdis |")};
+        #print "\n@llvm1\n\n";
+        #print "\n@llvm2\n\n";
+        remove($opt) unless count_insns(\@llvm1) <= count_insns(\@llvm2);
+        #print "----------------------------\n";
         status() if $VERBOSE;
     }
 
     print "; After triaging there are ".scalar(keys %toprint)." optimizations\n";
+}
+
+my %weaken_insn = (
+    "addnsw" => "add",
+    "addnuw" => "add",
+    "addnw" => "add",
+    "subnsw" => "sub",
+    "subnuw" => "sub",
+    "subnw" => "sub",
+    "mulnsw" => "mul",
+    "mulnuw" => "mul",
+    "mulnw" => "mul",
+    "udivexact" => "udiv",
+    "sdivexact" => "sdiv",
+    "shlnsw" => "shl",
+    "shlnuw" => "shl",
+    "shlnw" => "shl",
+    "lshrexact" => "lshr",
+    "ashrexact" => "ashr",
+    );
+
+sub replace_nth($$) {
+    (my $str, my $n) = @_;
+    my $count = 0;
+    my $in = 0;
+    for (my $pos = 0; $pos < length($str); $pos++) {
+	if (substr($str,$pos,1) eq "(") {
+	    die if $in;
+	    $in = 1;
+	    next;
+	}
+	if (substr($str,$pos,1) eq ")") {
+	    die unless $in;
+	    $in = 0;
+	    next;
+	}
+	if ($in) {
+	    my $c = substr($str,$pos,1);
+	    if ($c eq "0" || $c eq "1") {
+		if ($count == $n) {
+		    # print "found match $n at pos $pos\n";
+		    substr($str,$pos,1) = "x";
+		    return ($str, "bit");
+		}
+		$count++;
+	    }
+	    next;
+	}
+	my $rest = substr($str,$pos);
+	foreach my $k (keys %weaken_insn) {
+	    my $repl = $weaken_insn{$k};
+	    next unless ($rest =~ s/^$k/$repl/);
+	    if ($count == $n) {
+		return (substr($str,0,$pos).$rest,"insn");
+	    }
+	    $count++;
+	}
+    }
+    # print "did not find match $n\n";
+    return (undef, "");
+}
+
+my %weaken_yes = ("insn" => 0, "bit" => "0");
+my %weaken_no = ("insn" => 0, "bit" => "0");
+
+if ($WEAKEN) {
+    print "; Weakening\n";
+    my @keys = keys %toprint;
+    foreach my $opt (@keys) {
+	my $orig = $opt;
+	my $i = 0;
+	while (1) {
+	    (my $new, my $how) = replace_nth($opt, $i);
+	    last unless defined $new;
+	    if (checkstr($new)) {
+		$opt = $new;
+		$weaken_yes{$how}++;
+	    } else {
+		$weaken_no{$how}++;
+		$i++;
+	    }
+	}
+	die unless checkstr($opt);
+	$opt =~ s/ \(x+\)//g;
+	die unless checkstr($opt);
+	replace($orig, $opt) if ($opt ne $orig);
+    }
+    my $yes = $weaken_yes{"bit"};
+    my $no = $weaken_no{"bit"} + $weaken_yes{"bit"};
+    print "; weakening bits worked $yes / $no times\n";
+    $yes = $weaken_yes{"insn"};
+    $no = $weaken_no{"insn"} + $weaken_yes{"insn"};
+    print "; weakening insns worked $yes / $no times\n";
+    print "; After weakening there are ".scalar(keys %toprint)." optimizations\n";
+    # die unless ($tprofile == total_profile_count());
 }
 
 if ($MERGE) {
@@ -325,13 +486,37 @@ if ($MERGE) {
     # die unless ($tprofile == total_profile_count());
 }
 
+my %sprofile_rank;
+my %dprofile_rank;
+
+if ($SORT eq "combined") {
+    my $n=0;
+    foreach my $opt (sort { $sprofiles{$b} <=> $sprofiles{$a} } @all_keys) {
+        $sprofile_rank{$opt} = $n;
+        $n++;
+        # print "$sprofile{$opt} $opt\n\n";
+    }
+    $n=0;
+    foreach my $opt (sort { $dprofiles{$b} <=> $dprofiles{$a} } @all_keys) {
+        $dprofile_rank{$opt} = $n;
+        $n++;
+        # print "$dprofile{$opt} $opt\n\n";
+    }
+}
+
 sub bylen { length $a <=> length $b }
 sub bysprofile { $sprofiles{$b} <=> $sprofiles{$a} }
 sub bydprofile { $dprofiles{$b} <=> $dprofiles{$a} }
+sub byrank {
+    return
+        ($sprofile_rank{$a} + $dprofile_rank{$a}) <=>
+        ($sprofile_rank{$b} + $dprofile_rank{$b});
+}
 
 my $byx = \&bylen;
 $byx = \&bysprofile if ($SORT eq "sprofile");
 $byx = \&bydprofile if ($SORT eq "dprofile");
+$byx = \&byrank if ($SORT eq "combined");
 
 print "\n\n";
 
@@ -352,3 +537,10 @@ foreach my $opt (sort $byx keys %toprint) {
     }
     print "------------------------------------------------------\n\n";
 }
+
+my $cnt = 0;
+foreach my $opt (keys %toprint) {
+    $cnt += $sprofiles{$opt};
+}
+print "; overall total static profile weight = $cnt\n";
+print "; $tagged were tagged by cache_infer, $untagged were not\n";

--- a/utils/cache_import.in
+++ b/utils/cache_import.in
@@ -1,0 +1,94 @@
+#!/usr/bin/env perl
+
+# Copyright 2014 The Souper Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use warnings;
+use strict;
+use Redis;
+use Getopt::Long;
+use File::Temp;
+use Time::HiRes;
+
+my $llvmas = "@LLVM_BINDIR@/llvm-as";
+my $llvmopt = "@LLVM_BINDIR@/opt";
+my $llvmdis = "@LLVM_BINDIR@/llvm-dis";
+my $check = "@CMAKE_BINARY_DIR@/souper-check";
+my $reducer = "@CMAKE_BINARY_DIR@/reduce";
+my $triager = "@CMAKE_BINARY_DIR@/souper2llvm";
+
+sub parse ($) {
+    (my $opt) = @_;
+    (my $fh, my $tmpfn) = File::Temp::tempfile();
+    print $fh $opt;
+    $fh->flush();
+    my $arg = "--parse-lhs-only";
+    open INF, "${check} $arg < $tmpfn 2>/dev/null |";
+    my $output = "";
+    my $success = 0;
+    while (my $line = <INF>) {
+        $success = 1 if ($line =~ /success/);
+        next if ($line =~ /^;/);
+        $output .= $line;
+    }
+    close INF;
+    close $fh;
+    unlink $tmpfn;
+    print "'$opt' does not parse as Souper\n\n" unless $success;
+    return $success;
+}
+
+sub runit ($) {
+    my $cmd = shift;
+    my $res = (system "$cmd");
+    return $? >> 8;
+}
+
+my $r = Redis->new();
+$r->ping || die "no server?";
+
+my $cur;
+my $sprofile;
+my $known;
+my $n=0;
+while (my $line = <STDIN>) {
+    chomp $line;
+    if ($line =~ /\(hits ([0-9]+)\)/) {
+	print "$line\n";
+	$sprofile = $1;
+	die if defined $cur;
+	$cur = "";
+	next;
+    }
+    if ($line =~ /\/\/ \(([x01]+)\)/) {
+	$known = $1;
+	next;
+    }
+    $cur .= "${line}\n" if defined $cur;
+    next unless $line =~ /infer/;
+    die unless defined $cur;
+    if (parse($cur)) {
+	$n++;
+	my $old_profile = $r->hget($cur, "sprofile ");
+	$old_profile = 0 unless defined $old_profile;
+	$r->hset($cur, "sprofile ", $sprofile + $old_profile);
+	$r->hset($cur, "known", $known) if defined $known;
+    }
+    undef $cur;
+    undef $sprofile;
+    undef $known;
+}
+
+$r->save();
+print "imported $n LHSs\n";

--- a/utils/cache_infer.in
+++ b/utils/cache_infer.in
@@ -20,11 +20,14 @@ use Redis;
 use Getopt::Long;
 use File::Temp;
 use Time::HiRes;
+use BSD::Resource;
 
 eval { require Sys::CPU; Sys::CPU->import(); };
 
 my $NPROCS = 4;
 $NPROCS = Sys::CPU::cpu_count() if defined(&Sys::CPU::cpu_count);
+
+my $CPU_LIMIT = 15 * 60;
 
 sub usage() {
     print <<"END";
@@ -53,18 +56,13 @@ my $solver = $ENV{"SOUPER_SOLVER"};
 die $need_solver unless $solver;
 
 my $OPTS = "";
-$OPTS .= "-souper-infer-i1=false " if $ENV{"SOUPER_NO_INFER_I1"};
 $OPTS .= "-souper-infer-iN " if $ENV{"SOUPER_INFER_INT"};
-$OPTS .= "-souper-infer-nop " if $ENV{"SOUPER_INFER_NOP"};
-$OPTS .= "-souper-infer-unary " if $ENV{"SOUPER_INFER_UNARY"};
+
+$OPTS .= "-souper-synthesis-wiring-iterations=30 ";
+$OPTS .= "-souper-infer-inst ";
+$OPTS .= "-souper-synthesis-comps=mul,select,const,const,shl,lshr,ashr,and,or,xor,add,sub,slt,ult,sle,ule,eq,ne";
 
 my $check = "@CMAKE_BINARY_DIR@/souper-check -solver-timeout=15 ${solver}";
-
-sub runit ($) {
-    my $cmd = shift;
-    my $res = (system "$cmd");
-    return $? >> 8;
-}
 
 my $r = Redis->new();
 $r->ping || die "no server?";
@@ -74,8 +72,11 @@ sub infer($) {
     (my $k) = @_;
     (my $fh, my $tmpfn) = File::Temp::tempfile();
     print $fh $k;
+    my $cmd = "${check} -infer-rhs $OPTS";
+    print STDERR "\n$k\n\n";
+    print STDERR "$cmd\n";
     $fh->flush();
-    open INF, "${check} -infer-rhs $OPTS < $tmpfn |";
+    open INF, "$cmd < $tmpfn |";
     my $ok = 0;
     my $failed = 0;
     my $output = "";
@@ -90,7 +91,7 @@ sub infer($) {
         }
         $output .= $line;
     }
-    exit 1 unless $ok || $failed;
+    # exit 1 unless $ok || $failed;
     my $red = Redis->new();
     $red->ping || die "no server?";
     $red->hset($k, "cache-infer-tag" => $tag);
@@ -141,7 +142,52 @@ my $skip = 0;
 
 reset_status(scalar(@keys)) if $VERBOSE;
 
-foreach my $k (@keys) {
+my %sprofile;
+my %dprofile;
+
+foreach my $opt (@keys) {
+    $sprofile{$opt} = 0;
+    $dprofile{$opt} = 0;
+}
+
+foreach my $opt (@keys) {
+    my %h = $r->hgetall($opt);
+    foreach my $kk (keys %h) {
+        if ($kk =~ /^sprofile (.*)$/) {
+            my $count = $h{$kk};
+            $sprofile{$opt} += $count;
+        }
+        if ($kk =~ /^dprofile (.*)$/) {
+            my $count = $h{$kk};
+            $dprofile{$opt} += $count;
+        }
+    }
+}
+
+my %sprofile_rank;
+my %dprofile_rank;
+
+my $n=0;
+foreach my $opt (sort { $sprofile{$b} <=> $sprofile{$a} } @keys) {
+    $sprofile_rank{$opt} = $n;
+    $n++;
+    # print "$sprofile{$opt} $opt\n\n";
+}
+
+$n=0;
+foreach my $opt (sort { $dprofile{$b} <=> $dprofile{$a} } @keys) {
+    $dprofile_rank{$opt} = $n;
+    $n++;
+    # print "$dprofile{$opt} $opt\n\n";
+}
+
+sub byrank {
+    return
+        ($sprofile_rank{$a} + $dprofile_rank{$a}) <=>
+        ($sprofile_rank{$b} + $dprofile_rank{$b});
+}
+
+foreach my $k (sort byrank @keys) {
     status() if $VERBOSE;
     my $result = $r->hget($k, "cache-infer-tag");
     if (defined $result && $result eq $tag) {
@@ -152,7 +198,11 @@ foreach my $k (@keys) {
     die unless $num_running < $NPROCS;
     my $pid = fork();
     die unless $pid >= 0;
-    infer ($k) if $pid == 0;
+    if ($pid == 0) {
+	die "setrlimit" unless setrlimit(RLIMIT_CPU, $CPU_LIMIT, $CPU_LIMIT);
+	infer ($k);
+	# not reachable
+    }
     # make sure we're in the parent
     die unless $$ == $opid;
     $num_running++;

--- a/utils/souper2llvm.in
+++ b/utils/souper2llvm.in
@@ -317,7 +317,7 @@ def rewriteRegs(insts):
             assert not cand, "cand must be empty"
             cand = [newregs[reg], width, inst, ops]
             needsResult = True
-            continue
+            break
         elif inst == "result":
             assert needsResult, "infer inst not found"
             assert cand, "cand must not be empty"
@@ -379,13 +379,9 @@ def rewriteOps(inst, newregs, ops):
 def printFuncHeader():
     # global declarations: dummy store, intrinsics
     print "target datalayout = \"e-m:e-i64:64-f80:128-n8:16:32:64-S128\"\n"
-    print "@dummy1 = global i32 0, align 4"
-    print "@dummy2 = global i32 0, align 4"
-    print "@dummy3 = global i32 0, align 4"
-    print
     for decl in intrdecl.values():
         print decl
-    print "\ndefine void @foo(",
+    print "\ndefine " + cand[1] + " @foo(",
     # print args
     for i, reg in enumerate(argmap.values()):
         sys.stdout.write(widths[reg] + " " + reg)
@@ -434,16 +430,19 @@ def printFuncFooter():
         print "  ret void"
     print "}"
 
+def printLHSFuncFooter():
+    print "  ret " + cand[1] + " " + cand[0]
+    print "}"
+
 lines = readOpt()
 insts = parseInsts(lines)
 insts = propagateArgNames(insts)
 insts = groupPhis(insts)
 insts = rewriteRegs(insts)
 
-assert not needsResult, "result inst found"
 assert cand, "cand inst not found"
 
 printFuncHeader()
 printFuncBody(insts)
 printPCs()
-printFuncFooter()
+printLHSFuncFooter()


### PR DESCRIPTION
a new combined static/dynamic profile sort for cache_dump

cache_dump can "weaken" dataflow facts-- currently, drop known bits
that are not needed to make a given optimization go

synthesis support + timeouts for cache_infer

code from Raimondas for souper2llvm

new tool called cache_import that takes a dumped text file full of
optimizations and loads it into Redis