### PR TITLE
bugfix and cleanup suggested by John for printing var instruction with nzp option

### DIFF
--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -157,23 +157,19 @@ std::string ReplacementContext::printInst(Inst *I, llvm::raw_ostream &Out,
     default: {
       Out << "%" << InstName << ":i" << I->Width << " = "
           << Inst::getKindName(I->K);
-      if (I->K == Inst::Var && (I->KnownZeros.getBoolValue() || I->KnownOnes.getBoolValue()) &&
-          (I->PowOfTwo || I->NonNegative || I->NonZero)) {
-        Out << " (" << Inst::getKnownBitsString(I->KnownZeros, I->KnownOnes)
-            << ")" << " (" << Inst::getMoreKnownBitsString(I->NonZero, I->NonNegative, I->PowOfTwo)
-            << ")" << OpsSS.str();
-      } else if (I->K == Inst::Var && (I->KnownZeros.getBoolValue() || I->KnownOnes.getBoolValue())) {
-        Out << " (" << Inst::getKnownBitsString(I->KnownZeros, I->KnownOnes)
-            << ")" << OpsSS.str();
-      } else if (I->K == Inst::Var && (I->NonZero || I->NonNegative || I->PowOfTwo)) {
-        Out << " (" << Inst::getMoreKnownBitsString(I->NonZero, I->NonNegative, I->PowOfTwo)
-            << ")" << OpsSS.str();
-      } else {
-        Out << OpsSS.str();
+      if (I->K == Inst::Var) {
+        if (I->KnownZeros.getBoolValue() || I->KnownOnes.getBoolValue())
+          Out << " (" << Inst::getKnownBitsString(I->KnownZeros, I->KnownOnes)
+              << ")";
+        if (I->NonZero || I->NonNegative || I->PowOfTwo)
+          Out << " (" << Inst::getMoreKnownBitsString(I->NonZero,
+                                                      I->NonNegative,
+                                                      I->PowOfTwo)
+              << ")";
       }
-      if (printNames && !I->Name.empty()) {
+      Out << OpsSS.str();
+      if (printNames && !I->Name.empty())
         Out << " ; " << I->Name;
-      }
       Out << '\n';
       break;
     }
@@ -276,9 +272,9 @@ std::string Inst::getMoreKnownBitsString(bool NonZero, bool NonNegative, bool Po
   std::string Str;
   if (NonZero)
     Str.append("z");
-  else if (NonNegative)
+  if (NonNegative)
     Str.append("n");
-  else if (PowOfTwo)
+  if (PowOfTwo)
     Str.append("p");
   return Str;
 }

--- a/test/Tool/more-knownbits16.opt
+++ b/test/Tool/more-knownbits16.opt
@@ -1,0 +1,12 @@
+; REQUIRES: solver, solver-model
+
+; RUN: %souper-check %solver -infer-rhs -print-replacement %s > %t1 2>&1
+; RUN: FileCheck %s < %t1
+
+; CHECK: %0:i8 = var (znp)
+; CHECK-NEXT: %1:i1 = sle 1:i8, %0
+; CHECK-NEXT: cand %1 1:i1
+
+%0:i8 = var (nzp)
+%1:i1 = sle 1:i8, %0
+infer %1

--- a/test/Tool/more-knownbits17.opt
+++ b/test/Tool/more-knownbits17.opt
@@ -1,0 +1,12 @@
+; REQUIRES: solver, solver-model
+
+; RUN: %souper-check %solver -infer-rhs -print-replacement %s > %t1 2>&1
+; RUN: FileCheck %s < %t1
+
+; CHECK: %0:i16 = var (np)
+; CHECK-NEXT: %1:i1 = slt 0:i16, %0
+; CHECK-NEXT: cand %1 1:i1
+
+%0:i16 = var (np)
+%1:i1 = slt 0:i16, %0
+infer %1


### PR DESCRIPTION
There is a bug in function to print the non-zero, non-negative and power of two options printing in Inst.cpp. Invalid test cases are added to expose the bug.