### PR TITLE
Print command to execute to stderr

### DIFF
--- a/utils/sclang.in
+++ b/utils/sclang.in
@@ -224,9 +224,9 @@ if ((exists $ENV{"SOUPER_DYNAMIC_PROFILE"} ||
 
 if (exists $ENV{"SOUPER_DEBUG"}) {
     foreach my $arg (@ARGV) {
-        print "$arg ";
+        print STDERR "$arg ";
     }
-    print "\n";
+    print STDERR "\n";
 }
 
 exec @ARGV;


### PR DESCRIPTION
If `SOUPER_DEBUG` is on, sclang will emit the command to execute. But this is printed to stdout, which breaks tools that invoke the compiler and capture its stdout. This change switches it to stderr.