### PR TITLE
Bump to LLVM 3.9

### DIFF
--- a/tools/clang-souper.cpp
+++ b/tools/clang-souper.cpp
@@ -38,7 +38,7 @@ using namespace souper;
 static cl::OptionCategory ClangSouperCategory("clang-souper options");
 
 int main(int argc, const char **argv) {
-  llvm::sys::PrintStackTraceOnErrorSignal();
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
   CommonOptionsParser OptionsParser(argc, argv, ClangSouperCategory);
   ClangTool Tool(OptionsParser.getCompilations(),
                  OptionsParser.getSourcePathList());

--- a/tools/souper.cpp
+++ b/tools/souper.cpp
@@ -51,7 +51,7 @@ Check("check", cl::desc("Check input for expected results"),
     cl::init(false));
 
 int main(int argc, char **argv) {
-  sys::PrintStackTraceOnErrorSignal();
+  sys::PrintStackTraceOnErrorSignal(argv[0]);
   llvm::PrettyStackTraceProgram X(argc, argv);
 
   // Enable debug stream buffering.

--- a/update_deps.sh
+++ b/update_deps.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-llvm_revision=271510
+llvm_revision=280312
 klee_commit=a743d7072d9ccf11f96e3df45f25ad07da6ad9d6
 hiredis_commit=8f60ee65327445ed8384290b4040685329eb03c5
 


### PR DESCRIPTION
Changes were minimal to get Souper compiling against the LLVM 3.9 source base. Resolves #227.