### PR TITLE
Stop harvesting blockpc's if predecessors of phi node is another phi …

### DIFF
--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -602,10 +602,12 @@ void ExprBuilder::addPathConditions(BlockPCs &BPCs,
 
     VisitedBlocks.insert(BI.B);
     for (unsigned i = 0; i < BI.Preds.size(); ++i) {
-      std::vector<InstMapping> PCs;
-      addPathConditions(BPCs, PCs, VisitedBlocks, BI.Preds[i]);
-      for (auto PC : PCs)
-        BPCs.emplace_back(BlockPCMapping(BI.B, i, PC));
+      if (BI.Preds[i]->getSinglePredecessor()) {
+        std::vector<InstMapping> PCs;
+        addPathConditions(BPCs, PCs, VisitedBlocks, BI.Preds[i]);
+        for (auto PC : PCs)
+          BPCs.emplace_back(BlockPCMapping(BI.B, i, PC));
+      }
     }
   }
 }


### PR DESCRIPTION
…node
To find if a predecessor of phi node is another phi node, we simply look for the single predecessor and keep harvesting blockpc's for that. Otherwise, for predecessor block which has multiple predecessors (i.e. itself a phi node) is skipped and we don't harvest blockpc's for this predecessor.
