### PR TITLE
Apply UB constraints only on the relevant Select branches

### DIFF
--- a/test/Infer/select-invalid1.opt
+++ b/test/Infer/select-invalid1.opt
@@ -1,0 +1,16 @@
+; REQUIRES: solver, solver-model
+
+; RUN: %souper-check %solver -infer-rhs -souper-infer-iN %s > %t1
+; RUN: FileCheck %s < %t1
+
+; CHECK: Failed to infer RHS
+
+%0:i32 = var
+%1:i1 = ult 1:i32, %0
+%2:i32 = zext %1
+%3:i32 = lshr 10:i32, %0
+%4:i32 = select %1, %2, %3
+%5:i32 = addnsw %0, %4
+%6:i32 = and 255:i32, %5
+%7:i1 = ne 0:i32, %6
+infer %7

--- a/test/Solver/select-ub-predicates.ll
+++ b/test/Solver/select-ub-predicates.ll
@@ -1,0 +1,18 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+define i32 @foo(i32 %x0) {
+entry:
+  %shr = ashr i32 %x0, 27
+  %sub = add nsw i32 %shr, -27
+  %tobool = icmp ne i32 %sub, 0, !expected !1
+  %shr1 = lshr i32 1, %sub
+  %cond = select i1 %tobool, i32 %sub, i32 %shr1
+  %cmp = icmp ne i32 %cond, 0, !expected !1
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+!1 = !{ i1 1 }

--- a/test/Solver/select-ub-predicates2a.ll
+++ b/test/Solver/select-ub-predicates2a.ll
@@ -1,0 +1,19 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+define i1 @foo(i32 %a, i1 %b) {
+entry:
+  %0 = add nsw i32 %a, 1
+  br label %label1
+foo1:
+  %1 = add nsw i32 %a, 1
+  br label %label1
+label1:
+  %2 = phi i32 [ %0, %entry ], [ %1, %foo1 ] 
+  %3 = add i32 %a, 1
+  %4 = select i1 %b, i32 %2, i32 %3
+  %res = icmp sgt i32 %4, %a
+  ret i1 %res
+}

--- a/test/Solver/select-ub-predicates2b.ll
+++ b/test/Solver/select-ub-predicates2b.ll
@@ -1,0 +1,21 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+
+define i1 @foo(i32 %a, i1 %b) {
+entry:
+  %0 = add nsw i32 %a, 1
+  br label %label1
+foo1:
+  %1 = add nsw i32 %a, 1
+  br label %label1
+label1:
+  %2 = phi i32 [ %0, %entry ], [ %1, %foo1 ] 
+  %3 = add nsw i32 %a, 1
+  %4 = select i1 %b, i32 %2, i32 %3
+  %res = icmp sgt i32 %4, %a, !expected !1
+  ret i1 %res
+}
+
+!1 = !{ i1 1 }


### PR DESCRIPTION
This patch is based Raimondas's patch for addressing the issue #55.

https://github.com/rsas/souper/commit/66934ec740cb7f00d05362ed1b716b7330f6e136

One difference from the original patch is the part where we have to resolve
the issue caused by our cache mechanism, which was introduced after
the original patch.