### PR TITLE
Fixed issues for blockpcs

### DIFF
--- a/test/Extractor/blockpc3.ll
+++ b/test/Extractor/blockpc3.ll
@@ -1,0 +1,44 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+; RUN: FileCheck %s < %t
+
+; CHECK-NOT: cand
+
+@x3 = common global i32 0, align 4
+@x1 = common global i32 0, align 4
+@x0 = common global i32 0, align 4
+@x2 = common global i32 0, align 4
+
+; Function Attrs: norecurse nounwind uwtable
+define i32 @foo() #0 {
+entry:
+  %0 = load i32, i32* @x3, align 4
+  %tobool = icmp eq i32 %0, 0
+  br i1 %tobool, label %entry.if.end_crit_edge, label %if.then
+
+entry.if.end_crit_edge:                           ; preds = %entry
+  %.pre = load i32, i32* @x0, align 4
+  %.pre2 = load i32, i32* @x1, align 4
+  br label %if.end
+
+if.then:                                          ; preds = %entry
+  store i32 %0, i32* @x1, align 4
+  %.pr = load i32, i32* @x0, align 4
+  %cmp1 = icmp slt i32 %.pr, 1
+  br i1 %cmp1, label %for.inc.preheader, label %if.end
+
+for.inc.preheader:                                ; preds = %if.then
+  store i32 1, i32* @x0, align 4
+  br label %if.end
+
+if.end:                                           ; preds = %entry.if.end_crit_edge, %if.then, %for.inc.preheader
+  %1 = phi i32 [ %.pre2, %entry.if.end_crit_edge ], [ %0, %if.then ], [ %0, %for.inc.preheader ]
+  %2 = phi i32 [ %.pre, %entry.if.end_crit_edge ], [ %.pr, %if.then ], [ 1, %for.inc.preheader ]
+  %or = or i32 %1, %2
+  store i32 %or, i32* @x1, align 4
+  store i32 %or, i32* @x2, align 4
+  ret i32 %or
+}
+

--- a/test/Extractor/blockpc4.ll
+++ b/test/Extractor/blockpc4.ll
@@ -1,0 +1,68 @@
+; REQUIRES: solver
+
+; RUN: llvm-as -o %t %s
+; RUN: %souper %solver -check %t
+; RUN: FileCheck %s < %t
+
+; CHECK-NOT: cand
+
+@x4 = common global i32 0, align 4
+@x6 = common global i8 0, align 1
+@x1 = common global i32 0, align 4
+@x5 = common global i32 0, align 4
+@x0 = common global i32 0, align 4
+@x3 = common global i32 0, align 4
+@x2 = common global i32 0, align 4
+
+; Function Attrs: norecurse nounwind uwtable
+define i32 @foo() #0 {
+entry:
+  %0 = load i32, i32* @x4, align 4
+  %conv = trunc i32 %0 to i8
+  store i8 %conv, i8* @x6, align 1
+  %tobool = icmp eq i8 %conv, 0
+  br i1 %tobool, label %if.else, label %if.then
+
+if.then:                                          ; preds = %entry
+  %1 = load i32, i32* @x1, align 4
+  %cmp = icmp eq i32 %1, 0
+  %conv1 = zext i1 %cmp to i32
+  br i1 %cmp, label %cond.end, label %cond.false
+
+cond.false:                                       ; preds = %if.then
+  %rem = srem i32 %0, %1
+  br label %cond.end
+
+cond.end:                                         ; preds = %if.then, %cond.false
+  %cond = phi i32 [ %rem, %cond.false ], [ %conv1, %if.then ]
+  store i32 %cond, i32* @x5, align 4
+  %tobool2 = icmp eq i32 %cond, 0
+  br i1 %tobool2, label %if.end7, label %if.then3
+
+if.then3:                                         ; preds = %cond.end
+  store i32 0, i32* @x4, align 4
+  br label %if.end7
+
+if.else:                                          ; preds = %entry
+  %2 = load i32, i32* @x0, align 4
+  %tobool4 = icmp eq i32 %2, 0
+  br i1 %tobool4, label %if.end6, label %if.then5
+
+if.then5:                                         ; preds = %if.else
+  store i32 9, i32* @x4, align 4
+  br label %if.end6
+
+if.end6:                                          ; preds = %if.else, %if.then5
+  %3 = phi i32 [ %0, %if.else ], [ 9, %if.then5 ]
+  %4 = load i32, i32* @x3, align 4
+  %dec = add nsw i32 %4, -1
+  store i32 %dec, i32* @x3, align 4
+  br label %if.end7
+
+if.end7:                                          ; preds = %cond.end, %if.then3, %if.end6
+  %5 = phi i32 [ %0, %cond.end ], [ 0, %if.then3 ], [ %3, %if.end6 ]
+  %cmp8 = icmp sgt i32 %5, 0
+  %conv9 = zext i1 %cmp8 to i32
+  store i32 %conv9, i32* @x2, align 4
+  ret i32 %conv9
+}

--- a/test/Infer/blockpc-invalid1.opt
+++ b/test/Infer/blockpc-invalid1.opt
@@ -1,0 +1,21 @@
+; REQUIRES: solver, solver-model
+
+; RUN: %souper-check %solver -infer-rhs -souper-infer-iN %s > %t1
+; RUN: FileCheck %s < %t1
+
+; CHECK: Failed to infer RHS
+
+%0 = block 2
+%1:i8 = var
+%2:i1 = ne 0:i8, %1
+blockpc %0 0 %2 0:i1
+blockpc %0 1 %2 1:i1
+%3 = block 3
+%4:i32 = var
+%5:i8 = phi %0, 70:i8, 1:i8
+%6:i32 = sext %5
+%7:i32 = ashr %4, %6
+%8:i1 = ne 0:i32, %7
+blockpc %3 0 %8 0:i1
+%9:i1 = slt %6, 6:i32
+infer %9

--- a/test/Infer/blockpc-invalid2.opt
+++ b/test/Infer/blockpc-invalid2.opt
@@ -1,0 +1,20 @@
+; REQUIRES: solver, solver-model
+
+; RUN: %souper-check %solver -infer-rhs -souper-infer-iN %s > %t1
+; RUN: FileCheck %s < %t1
+
+; CHECK: Failed to infer RHS
+
+%0 = block 2
+%1:i8 = var
+%2:i1 = slt 1:i8, %1
+blockpc %0 0 %2 1:i1
+blockpc %0 1 %2 0:i1
+%3:i32 = var
+%4:i32 = sext %1
+%5:i32 = ashr %3, %4
+%6:i1 = ne 0:i32, %5
+%7:i1 = phi %0, 1:i1, %6
+%8:i32 = zext %7
+%9:i32 = select %7, %8, %3
+infer %9

--- a/test/Infer/blockpc3.opt
+++ b/test/Infer/blockpc3.opt
@@ -1,0 +1,17 @@
+; REQUIRES: solver, solver-model
+
+; RUN: %souper-check %solver -infer-rhs -souper-infer-iN %s > %t
+; RUN: FileCheck %s -check-prefix=SUCCESS < %t
+
+; SUCCESS: result 0:i32
+
+%0 = block 2
+%1:i32 = var
+%2:i32 = srem %1, 2:i32
+%3:i1 = ne 0:i32, %2
+blockpc %0 0 %3 1:i1
+blockpc %0 1 %3 0:i1
+%4:i32 = addnsw 1:i32, %1
+%5:i32 = phi %0, %4, %1
+%6:i32 = and 1:i32, %5
+infer %6

--- a/test/Infer/blockpc4.opt
+++ b/test/Infer/blockpc4.opt
@@ -1,0 +1,25 @@
+; REQUIRES: solver, solver-model
+
+; RUN: %souper-check %solver -infer-rhs -souper-infer-iN %s > %t
+; RUN: FileCheck %s -check-prefix=SUCCESS < %t
+
+; SUCCESS: result 3:i32
+
+%0 = block 4
+%1:i32 = var
+%2:i32 = urem %1, 4:i32
+%3:i1 = ne 0:i32, %2
+blockpc %0 0 %3 1:i1
+%4:i1 = ne 1:i32, %2
+blockpc %0 0 %4 1:i1
+%5:i1 = ne 2:i32, %2
+blockpc %0 0 %5 1:i1
+blockpc %0 1 %2 2:i32
+blockpc %0 2 %2 1:i32
+blockpc %0 3 %2 0:i32
+%6:i32 = add 1:i32, %1
+%7:i32 = add 2:i32, %1
+%8:i32 = add 3:i32, %1
+%9:i32 = phi %0, %1, %6, %7, %8
+%10:i32 = and 3:i32, %9
+infer %10


### PR DESCRIPTION
This patch fixed following issues for blockpcs:

* When we harvested blockpcs for an instruction, we didn't handle
cases where a direct incoming branch is of a br/switch instruction.
This oversight caused us to miss optimization opportunities. This
patch fixed this issue.

* included Jubi's fix to blockpc soundness issue.

We stop harvesting blockpc when encountering a second phi node.

* don't collect UB instructions for a blockpc without predictions

Previously, we rely on the nullability of UBInstPrecondition to
separate UB instructions from PCs and BlockPCs. However, in cases
where the relevant Phi nodes are not part of the Souper IR,
we can have a null precondition for a BlockPC. Consequently,
we would introduce UB into souper. Note that we create klee exprs
for an UBInst only if it's recorded in the UBExprMap.

This patch fixed this issue by explictly check if we currently
process a PC or BlockPC.

* don't crash on revisiting phis and blocks

Because we treat select instructions as phis, it's incorrect
to assume that we would never re-visit phis or blocks during
processing blockpcs. Just skip those cases.