### PR TITLE
add nop inference, which guesses that the synthesized quantity is

### DIFF
--- a/test/Infer/nop1.opt
+++ b/test/Infer/nop1.opt
@@ -1,0 +1,10 @@
+; REQUIRES: solver
+; RUN: %souper-check -infer-rhs -souper-infer-nop %solver %s | FileCheck %s
+; CHECK: result %1
+
+%0:i32 = var
+%1:i32 = var
+%2:i32 = xor %0, %1
+%3:i32 = xor %1, %2
+%4:i32 = xor %2, %3
+infer %4

--- a/test/Infer/rot.ll
+++ b/test/Infer/rot.ll
@@ -1,0 +1,25 @@
+; REQUIRES: solver
+; RUN: llvm-as %s -o - | %souper %solver -souper-infer-nop > %t2
+; RUN: FileCheck %s < %t2
+; CHECK: cand %5 %0
+
+; ModuleID = 'foo.ll'
+source_filename = "foo.c"
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: nounwind uwtable
+define i32 @nop1(i32) #0 {
+  %2 = shl i32 %0, 16
+  %3 = lshr i32 %0, 16
+  %4 = lshr i32 %2, 16
+  %5 = shl i32 %3, 16
+  %6 = or i32 %4, %5
+  ret i32 %6
+}
+
+attributes #0 = { nounwind uwtable "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.ident = !{!0}
+
+!0 = !{!"clang version 3.9.0 (tags/RELEASE_390/final)"}


### PR DESCRIPTION
equivalent to one of its inputs

souper can already do this using synthesis but it is hard: souper must
synthesize the entire RHS from scratch; just guessing that the output
is equal to an input is far easier and faster

in the future we might also guess that the output is equivalent to
some intermediate value on the LHS, this is trivial