### PR TITLE
in some cases Souper gets asked to infer a value that is trivially

### DIFF
--- a/lib/Extractor/Solver.cpp
+++ b/lib/Extractor/Solver.cpp
@@ -142,6 +142,8 @@ public:
       std::set<Inst *> Visited;
       findVars(LHS, Visited, Guesses, LHS->Width);
       for (auto I : Guesses) {
+        if (LHS == I)
+          continue;
         InstMapping Mapping(LHS, I);
         std::string Query = BuildQuery(BPCs, PCs, Mapping, 0);
         if (Query.empty())


### PR DESCRIPTION
the same as an input-- don't do nop inference or those cases