### PR TITLE
stop souper from deleting instructions (which might have side effects…

### DIFF
--- a/lib/Pass/Pass.cpp
+++ b/lib/Pass/Pass.cpp
@@ -258,8 +258,7 @@ public:
       if (ReplaceCount >= FirstReplace && ReplaceCount <= LastReplace) {
         if (DynamicProfile)
           dynamicProfile(F, Cand);
-        BasicBlock::iterator BI(I);
-        ReplaceInstWithValue(I->getParent()->getInstList(), BI, CI);
+        I->replaceAllUsesWith(CI);
         Changed = true;
       } else {
         if (DebugSouperPass)


### PR DESCRIPTION
… or be terminators)

this leaves a dead instruction for LLVM to remove, if it can