### PR TITLE
Keep counterexample wirings

### DIFF
--- a/include/souper/Infer/InstSynthesis.h
+++ b/include/souper/Infer/InstSynthesis.h
@@ -294,6 +294,7 @@ private:
   bool isWiringInvalid(const LocVar &Left, const LocVar &Right);
   void forbidInvalidCandWiring(const ProgramWiring &CandWiring,
                                std::vector<InstMapping> &LoopPCs,
+                               std::vector<InstMapping> &WiringPCs,
                                InstContext &IC);
   int costHelper(Inst *I, std::set<Inst *> &Visited);
   int cost(Inst *I);
@@ -307,7 +308,8 @@ private:
                             const ProgramWiring &CandWiring,
                             std::map<ProgramWiring, unsigned> &NotWorkingConstWirings,
                             const std::map<LocVar, llvm::APInt> &ConstValMap,
-                            std::vector<InstMapping> &LoopPCs);
+                            std::vector<InstMapping> &LoopPCs,
+                            std::vector<InstMapping> &WiringPCs);
 
 };
 

--- a/lib/Infer/InstSynthesis.cpp
+++ b/lib/Infer/InstSynthesis.cpp
@@ -747,7 +747,6 @@ Inst *InstSynthesis::getInputDefinednessConstraint(InstContext &IC) {
   if (DebugLevel > 2)
     llvm::outs() << "input-definedness constraints:\n";
   for (auto const &L_x : P) {
-    unsigned Width = CompInstMap[L_x.first]->Width;
     Inst *Ante = IC.getConst(APInt(1, false));
     // Inputs
     for (auto const &In : I) {
@@ -787,7 +786,6 @@ Inst *InstSynthesis::getOutputDefinednessConstraint(InstContext &IC) {
 
   if (DebugLevel > 2)
     llvm::outs() << "output-definedness constraints:\n";
-  unsigned Width = CompInstMap[O.first]->Width;
   // Inputs
   for (auto const &In : I) {
     if (isWiringInvalid(In.first, O.first))


### PR DESCRIPTION
This fix cuts the test time of HackersDelight synthesis tests from 17 to 9 seconds on my iMac.