### PR TITLE
souper-check crashed when extractvalue instruction extracted from non…

### DIFF
--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -622,9 +622,21 @@ bool Parser::typeCheckInst(Inst::Kind IK, unsigned &Width,
           ErrStr = "extract value expects an aggregate type";
           return false;
       }
-    } else if (Ops[1]->Val.getZExtValue() == 1)
-      ExpectedWidth = 1;
-    else
+    } else if (Ops[1]->Val.getZExtValue() == 1) {
+      switch (Ops[0]->K) {
+        case Inst::SAddWithOverflow:
+        case Inst::UAddWithOverflow:
+        case Inst::SSubWithOverflow:
+        case Inst::USubWithOverflow:
+        case Inst::SMulWithOverflow:
+        case Inst::UMulWithOverflow:
+          ExpectedWidth = 1;
+          break;
+        default:
+          ErrStr = "extract value expects an aggregate type";
+          return false;
+      }
+    } else
       ErrStr = "extractvalue inst doesn't expect index value other than 0 or 1";
     break;
 

--- a/unittests/Parser/ParserTests.cpp
+++ b/unittests/Parser/ParserTests.cpp
@@ -96,11 +96,23 @@ TEST(ParserTest, Errors) {
         "%1:i1 = extractvalue %0, 1:i32\n"
         "infer %1\n",
         "<input>:1:1: at least one operand must be typed" },
-      { "%0:i65 = var ; 0\n%1:i1 = extractvalue %0, 1:i32\n"
-        "%2:i64 = extractvalue %0, 0:i32\n"
+      { "%0:i65 = var ; 0\n%1:i1 = extractvalue %0, 1\n"
+        "%2:i64 = extractvalue %0, 0\n"
         "%3:i64 = select %1, 18446744073709551615:i64, %2\n"
         "infer %3\n",
-        "<input>:3:1: extract value expects an aggregate type" },
+        "<input>:2:1: extract value expects an aggregate type" },
+      { "%0:i65 = var ; 0\n"
+        "%1:i64 = extractvalue %0, 0\n"
+        "infer %1\n",
+        "<input>:2:1: extract value expects an aggregate type" },
+      { "%0:i65 = var ; 0\n"
+        "%1:i1 = extractvalue %0, 1\n"
+        "infer %1\n",
+        "<input>:2:1: extract value expects an aggregate type" },
+      { "%0:i64 = var ; 0\n"
+        "%1:i1 = extractvalue 42, 1\n"
+        "infer %1\n",
+        "<input>:2:1: extract value expects an aggregate type" },
       { "%0:i4 = var (knownBits=001x) (nonZero\n",
         "<input>:1:1: expected ')' to complete data flow fact string" },
       { "%0:i4 = var (nonZero\n",


### PR DESCRIPTION
…-aggregate type