### PR TITLE
don't try to turn a string into a too-short APInt or else LLVM will

### DIFF
--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -219,6 +219,11 @@ FoundChar:
         ErrStr = "width must be at least 1";
         return Token{Token::Error, WidthBegin, 0, APInt()};
       }
+      // this calculation is from an assertion in APInt::fromString()
+      if ((((NumEnd - NumBegin) - 1) * 64) / 22 > Width) {
+        ErrStr = "integer too large for its width";
+        return Token{Token::Error, Begin, 0, APInt()};
+      }
       return Token{Token::Int, NumBegin, size_t(Begin - NumBegin),
                    APInt(Width, StringRef(NumBegin, NumEnd - NumBegin), 10)};
     }

--- a/unittests/Parser/ParserTests.cpp
+++ b/unittests/Parser/ParserTests.cpp
@@ -36,6 +36,8 @@ TEST(ParserTest, Errors) {
       { "%0:i32 = -", "<input>:1:11: unexpected character following a negative sign" },
 
       // parsing
+      { "pc 55555550:i5\n",
+        "<input>:1:15: integer too large for its width" },
       { "%0:i32 = var\n%1:i1 = eq %0:i32, %0:i32\n",
         "<input>:2:12: inst reference may not have a width" },
       { "%0:i1 = eq %1, %1\n", "<input>:1:12: %1 is not an inst" },


### PR DESCRIPTION
assert out