### PR TITLE
a huge number of block predecessors was getting turned into ~0

### DIFF
--- a/include/souper/Inst/Inst.h
+++ b/include/souper/Inst/Inst.h
@@ -25,6 +25,8 @@
 
 namespace souper {
 
+const unsigned MaxPreds = 100000;
+
 struct Block {
   std::string Name;
   unsigned Preds;

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -953,7 +953,11 @@ bool Parser::parseLine(std::string &ErrStr) {
             return false;
           }
           unsigned Preds = CurTok.Val.getLimitedValue();
-
+          if (Preds > MaxPreds) {
+            ErrStr = makeErrStr(std::string(std::to_string(Preds) +
+                                            " is too many block predecessors"));
+            return false;
+          }
           Context.setBlock(InstName, IC.createBlock(Preds));
           return consumeToken(ErrStr);
         } else {

--- a/unittests/Parser/ParserTests.cpp
+++ b/unittests/Parser/ParserTests.cpp
@@ -36,6 +36,8 @@ TEST(ParserTest, Errors) {
       { "%0:i32 = -", "<input>:1:11: unexpected character following a negative sign" },
 
       // parsing
+      { "%2 = block 111111111111111111111\n",
+        "<input>:1:12: 4294967295 is too many block predecessors" },
       { "pc 55555550:i5\n",
         "<input>:1:15: integer too large for its width" },
       { "%0:i32 = var\n%1:i1 = eq %0:i32, %0:i32\n",


### PR DESCRIPTION
and then triggering a tombstone value in LLVM's DenseMap.

a sensible way to fix seems to be to put an arbitrary (but enormous)
limit on the number of predecessors