### PR TITLE
overflow intrinsics are not allowed to be inferred, only

### DIFF
--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -775,6 +775,19 @@ bool Parser::parseLine(std::string &ErrStr) {
         if (!parseDemandedBits(ErrStr, Cand.LHS))
           return false;
 
+        switch(Cand.LHS->K) {
+          case Inst::SAddWithOverflow:
+          case Inst::UAddWithOverflow:
+          case Inst::SSubWithOverflow:
+          case Inst::USubWithOverflow:
+          case Inst::SMulWithOverflow:
+          case Inst::UMulWithOverflow:
+            ErrStr = makeErrStr("unexpected instruction kind in cand");
+            return false;
+          default:
+            break;
+        }
+
         Reps.push_back(ParsedReplacement{Cand, std::move(PCs),
                                          std::move(BPCs)});
         nextReplacement();
@@ -800,6 +813,19 @@ bool Parser::parseLine(std::string &ErrStr) {
 
         if (!parseDemandedBits(ErrStr, LHS))
           return false;
+
+        switch (LHS->K) {
+          case Inst::SAddWithOverflow:
+          case Inst::UAddWithOverflow:
+          case Inst::SSubWithOverflow:
+          case Inst::USubWithOverflow:
+          case Inst::SMulWithOverflow:
+          case Inst::UMulWithOverflow:
+            ErrStr = makeErrStr("unexpected instruction kind in infer");
+            return false;
+          default:
+            break;
+        }
 
         if (RK == ReplacementKind::ParseLHS) {
           Reps.push_back(ParsedReplacement{InstMapping(LHS, 0),

--- a/unittests/Parser/ParserTests.cpp
+++ b/unittests/Parser/ParserTests.cpp
@@ -300,6 +300,18 @@ TEST(ParserTest, FullReplacementErrors) {
         "<input>:3:1: expected ')' to complete demandedBits data flow string" },
       { "%0:i4 = var ; 0\ncand %0 7:i4 (demandedBits=2111)\n",
         "<input>:2:28: expected demandedBits pattern of type [0|1]+" },
+      { "%0:i64 = var ; 0\n"
+        "%1 = and %0, 1\n"
+        "%2 = sadd.with.overflow %0, 1\n"
+        "%3 = extractvalue %2, 1\n"
+        "infer %2\n",
+        "<input>:6:1: unexpected instruction kind in infer" },
+      { "%0:i64 = var ; 0\n"
+        "%1 = and %0, 1\n"
+        "%2 = sadd.with.overflow %0, 1\n"
+        "%3 = extractvalue %2, 1\n"
+        "cand %2 1\n",
+        "<input>:6:1: unexpected instruction kind in cand" },
 
       // type checking
     };


### PR DESCRIPTION
the overflow bit or operand's bitwidth result can be returned

souper-check returned protocol error earlier when overflow intrinsic was inferred.