### PR TITLE
absurd argument values were causing APInt to assert out, and

### DIFF
--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -620,7 +620,7 @@ bool Parser::typeCheckInst(Inst::Kind IK, unsigned &Width,
     break;
 
   case Inst::ExtractValue:
-    if (Ops[1]->Val.getZExtValue() == 0) {
+    if (Ops[1]->Val == 0) {
       switch (Ops[0]->K) {
         case Inst::SAddWithOverflow:
         case Inst::UAddWithOverflow:
@@ -634,7 +634,7 @@ bool Parser::typeCheckInst(Inst::Kind IK, unsigned &Width,
           ErrStr = "extract value expects an aggregate type";
           return false;
       }
-    } else if (Ops[1]->Val.getZExtValue() == 1) {
+    } else if (Ops[1]->Val == 1) {
       switch (Ops[0]->K) {
         case Inst::SAddWithOverflow:
         case Inst::UAddWithOverflow:
@@ -648,8 +648,10 @@ bool Parser::typeCheckInst(Inst::Kind IK, unsigned &Width,
           ErrStr = "extract value expects an aggregate type";
           return false;
       }
-    } else
+    } else {
       ErrStr = "extractvalue inst doesn't expect index value other than 0 or 1";
+      return false;
+    }
     break;
 
   default:

--- a/unittests/Parser/ParserTests.cpp
+++ b/unittests/Parser/ParserTests.cpp
@@ -112,6 +112,11 @@ TEST(ParserTest, Errors) {
         "%3:i64 = select %1, 18446744073709551615:i64, %2\n"
         "infer %3\n",
         "<input>:2:1: extract value expects an aggregate type" },
+      { "%0:i8 = var\n"
+        "%1:i8 = var\n"
+         "%2:i9 = smul.with.overflow %0, %1\n"
+        "%3 = extractvalue %2, 999999999999999999999999999999999999999999999999999999999999999999999999999",
+      "<input>:4:1: extractvalue inst doesn't expect index value other than 0 or 1" },
       { "%0:i65 = var ; 0\n"
         "%1:i64 = extractvalue %0, 0\n"
         "infer %1\n",


### PR DESCRIPTION
there's a better way to compare APInts anyway