### PR TITLE
souper's parser has some basic forward type inference where widths

### DIFF
--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -671,6 +671,27 @@ bool Parser::typeCheckInst(Inst::Kind IK, unsigned &Width,
     return false;
   }
 
+  switch (IK) {
+  case Inst::BSwap:
+    if (Width != 16 && Width != 32 && Width != 64) {
+      ErrStr = "bswap doesn't support " + std::to_string(Width) + " bits";
+      return false;
+    }
+    break;
+  case Inst::CtPop:
+  case Inst::Ctlz:
+  case Inst::Cttz:
+    if (Width !=8 && Width != 16 && Width != 32 &&
+        Width != 64 && Width != 256) {
+      ErrStr = std::string(Inst::getKindName(IK)) + " doesn't support " +
+        std::to_string(Width) + " bits";
+      return false;
+    }
+    break;
+  default:
+    break;
+  }
+
   return true;
 }
 
@@ -952,21 +973,6 @@ bool Parser::parseLine(std::string &ErrStr) {
 
       Inst::Kind IK = Inst::getKind(CurTok.str());
 
-      if (IK == Inst::BSwap) {
-        if (InstWidth != 16 && InstWidth != 32 && InstWidth != 64) {
-          ErrStr = makeErrStr(TP, CurTok.str().str() + " doesn't support " +
-                              std::to_string(InstWidth) + " bits");
-          return false;
-        }
-      }
-      if ((IK == Inst::CtPop) || (IK == Inst::Ctlz) || (IK == Inst::Cttz)) {
-        if (InstWidth !=8 && InstWidth != 16 && InstWidth != 32 &&
-            InstWidth != 64 && InstWidth != 256) {
-          ErrStr = makeErrStr(TP, CurTok.str().str() + " doesn't support " +
-                              std::to_string(InstWidth) + " bits");
-          return false;
-        }
-      }
       if (IK == Inst::None) {
         if (CurTok.str() == "block") {
           if (InstWidth != 0) {

--- a/test/Tool/more-knownbits7.opt
+++ b/test/Tool/more-knownbits7.opt
@@ -6,7 +6,7 @@
 ; CHECK: LGTM
 %0:i32 = var (powerOfTwo)
 %1:i32 = var
-%2:i32 = lshrexact %0, %1
-%3:i32 = ctpop %2
-%4:i1 = eq %3, 1:i32
+%2 = lshrexact %0, %1
+%3 = ctpop %2
+%4 = eq %3, 1:i32
 cand %4 1:i1

--- a/test/Tool/signbits6.opt
+++ b/test/Tool/signbits6.opt
@@ -5,6 +5,6 @@
 
 ; CHECK: LGTM
 %0:i32 = var (powerOfTwo) (signBits=31)
-%1:i32 = cttz %0
-%2:i1 = eq %1, 0:i32
+%1 = cttz %0
+%2 = eq %1, 0:i32
 cand %2 1:i1


### PR DESCRIPTION
don't need to always be specified

some error checking specific to ctpop/cttz/ctlz/bswap was breaking
type inference for those instructions since the checking was done too
early, this PR fixes that