### PR TITLE
argh, DemandedBits needs a default value or else it doesn't work to

### DIFF
--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -606,6 +606,7 @@ Inst *InstContext::getInst(Inst::Kind K, unsigned Width,
   N->K = K;
   N->Width = Width;
   N->Ops = *InstOps;
+  N->DemandedBits = llvm::APInt::getAllOnesValue(Width);
   InstSet.InsertNode(N, IP);
   return N;
 }


### PR DESCRIPTION
create custom Souper LHSs from scratch, as we want to do in the
Solver, this was causing ugly wrong behaviors

I think this fixes an issue Raimondas and I were having