### PR TITLE
run CI tests under UBSan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 from ubuntu:16.04
 
 run set -x; \
-        apt-get update \
+        apt-get update -qq \
+        && apt-get remove -y -qq clang llvm llvm-runtime \
 	&& apt-get install libgmp10 \
 	&& echo 'ca-certificates gcc g++ valgrind libc6-dev libgmp-dev cmake ninja-build make autoconf automake libtool golang-go python subversion git' > /usr/src/build-deps \
 	&& apt-get install -y $(cat /usr/src/build-deps) --no-install-recommends \

--- a/clone_and_test.sh
+++ b/clone_and_test.sh
@@ -47,6 +47,16 @@ LIT_ARGS="-v -vv" ./run_lit
 LIT_ARGS="-v -vv --vg --vg-arg=--trace-children-skip=$Z3 --vg-arg=--suppressions=$SRCDIR/valgrind.supp" ./run_lit
 cd ..
 
+# TODO: turn on ASan as well, which requires LLVM to be built with it
+# in order to get our pass to work
+
+mkdir build-release-sanitize
+cd build-release-sanitize
+PATH=/usr/src/souper/third_party/llvm/Release/bin:$PATH cmake -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_FLAGS='-fsanitize=undefined -fno-sanitize-recover=all' -DTEST_SOLVER=-z3-path=$Z3 -DTEST_SYNTHESIS=ON -DCMAKE_BUILD_TYPE=Release ..
+ninja
+LIT_ARGS="-v -vv" ./run_lit
+cd ..
+
 #mkdir build-debug
 #cd build-debug
 #cmake -G Ninja -DTEST_SOLVER=-z3-path=$Z3 -DTEST_SYNTHESIS=ON -DCMAKE_BUILD_TYPE=Debug ..


### PR DESCRIPTION
  this has the happy side effect of having CI make sure that souper builds and works using both LLVM and GCC