### PR TITLE
new mode for souper-check that takes a complete replacement, forgets

### DIFF
--- a/include/souper/Infer/InstSynthesis.h
+++ b/include/souper/Infer/InstSynthesis.h
@@ -302,8 +302,6 @@ private:
                                std::vector<InstMapping> &LoopPCs,
                                std::vector<InstMapping> &WiringPCs,
                                InstContext &IC);
-  int costHelper(Inst *I, std::set<Inst *> &Visited);
-  int cost(Inst *I);
   bool hasConst(Inst *I);
   std::error_code getInitialConcreteInputs(std::vector<std::map<Inst *, Inst *>> &S,
                                            unsigned NumInputs);

--- a/include/souper/Inst/Inst.h
+++ b/include/souper/Inst/Inst.h
@@ -18,10 +18,11 @@
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FoldingSet.h"
+#include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
-#include <map>
 
 namespace souper {
 
@@ -203,6 +204,8 @@ public:
 
   Inst *getInst(Inst::Kind K, unsigned Width, const std::vector<Inst *> &Ops);
 };
+
+int cost(Inst *I);
 
 void PrintReplacement(llvm::raw_ostream &Out, const BlockPCs &BPCs,
                       const std::vector<InstMapping> &PCs, InstMapping Mapping,

--- a/lib/Infer/InstSynthesis.cpp
+++ b/lib/Infer/InstSynthesis.cpp
@@ -1320,20 +1320,6 @@ void InstSynthesis::forbidInvalidCandWiring(const ProgramWiring &CandWiring,
   WiringPCs.emplace_back(Ante, IC.getConst(APInt(1, false)));
 }
 
-int InstSynthesis::costHelper(Inst *I, std::set<Inst *> &Visited) {
-  if (!Visited.insert(I).second)
-    return 0;
-  int Cost = Inst::getCost(I->K);
-  for (auto Op : I->Ops)
-    Cost += costHelper(Op, Visited);
-  return Cost;
-}
-
-int InstSynthesis::cost(Inst *I) {
-  std::set<Inst *> Visited;
-  return costHelper(I, Visited);
-}
-
 bool InstSynthesis::hasConst(Inst *I) {
   if (I->K == Inst::Const)
     return true;

--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -648,6 +648,20 @@ int Inst::getCost(Inst::Kind K) {
   }
 }
 
+static int costHelper(Inst *I, std::set<Inst *> &Visited) {
+  if (!Visited.insert(I).second)
+    return 0;
+  int Cost = Inst::getCost(I->K);
+  for (auto Op : I->Ops)
+    Cost += costHelper(Op, Visited);
+  return Cost;
+}
+
+int souper::cost(Inst *I) {
+  std::set<Inst *> Visited;
+  return costHelper(I, Visited);
+}
+
 void souper::PrintReplacement(llvm::raw_ostream &Out,
                               const BlockPCs &BPCs,
                               const std::vector<InstMapping> &PCs,

--- a/test/Infer/alive-reinfer.opt
+++ b/test/Infer/alive-reinfer.opt
@@ -1,0 +1,29 @@
+; REQUIRES: solver, solver-model, synthesis
+
+; RUN: %souper-check %solver -reinfer-rhs -souper-infer-inst -souper-synthesis-ignore-cost -souper-synthesis-comps=const,and,sub,or %s > %t1
+; RUN: FileCheck %s < %t1
+
+; CHECK: no cost regression
+; CHECK: no cost regression
+
+%Z:i32 = var
+%RHS:i32 = var
+%Y = or %Z, 4042322160 ; 0xf0f0f0f0
+%X = xor %Y, 252645135 ; 0x0f0f0f0f
+%LHS = add %X, 1
+%r = add %LHS, %RHS
+infer %r
+%and = and %Z, 252645135
+%r2 = sub %RHS, %and
+result %r2
+
+%Z:i64 = var
+%RHS:i64 = var
+%Y = and %Z, 25029374298723009
+%X = xor %Y, 25029374298723009
+%LHS = add %X, 1
+%r = add %LHS, %RHS
+infer %r
+%or = or %Z, -25029374298723010
+%r2 = sub %RHS, %or
+result %r2

--- a/test/Infer/reinfer-fail.opt
+++ b/test/Infer/reinfer-fail.opt
@@ -1,0 +1,30 @@
+; REQUIRES: solver, solver-model, synthesis
+
+; RUN: %souper-check %solver -reinfer-rhs -souper-infer-inst -souper-synthesis-ignore-cost -souper-synthesis-comps=ctpop,ctpop,or,const,const,eq,eq %s > %t1
+; RUN: FileCheck %s < %t1
+
+; CHECK: cost regressed
+
+%x:i8 = var
+%b1 = eq %x, 1
+%b2 = eq %x, 2
+%b3 = eq %x, 4
+%b4 = eq %x, 8
+%b5 = eq %x, 16
+%b6 = eq %x, 32
+%b7 = eq %x, 64
+%b8 = eq %x, 128
+%ba = or %b1, %b2
+%bb = or %b3, %b4
+%bc = or %b5, %b6
+%bd = or %b7, %b8
+%be = or %ba, %bb
+%bf = or %bc, %bd
+%bg = or %be, %bf
+%bh = eq %x, 0
+%res = or %bg, %bh
+infer %res
+%z1 = sub 0, %x
+%z2 = and %x, %z1
+%z3 = eq %x, %z2
+result %z3

--- a/test/Infer/reinfer.opt
+++ b/test/Infer/reinfer.opt
@@ -1,0 +1,38 @@
+; REQUIRES: solver
+
+; RUN: %souper-check %solver -print-counterexample=false -reinfer-rhs %s > %t 2>&1
+; RUN: FileCheck %s < %t
+; CHECK: no cost regression
+; CHECK: no cost regression
+; CHECK: no cost regression
+; CHECK: no cost regression
+; CHECK: no cost regression
+
+%0:i8 = var (knownBits=xxxx0000)
+%1:i8 = var (knownBits=0000xxxx)
+%2:i8 = and %0, %1
+%3:i1 = eq %2, 0:i8
+cand %3 1:i1
+
+%0:i16 = var (knownBits=1x1x1x1x1x1x1x1x)
+%1:i16 = var (knownBits=x1x1x1x1x1x1x1x1)
+%2:i16 = or %0, %1
+%3:i1 = eq %2, 65535:i16
+cand %3 1:i1
+
+%0:i64 = var (knownBits=1111111111111111111111111111111111111111111111111111111111111111)
+%1:i64 = var (knownBits=0000000000000000000000000000000000000000000000000000000000000000)
+%2:i64 = and %0, %1
+%3:i1 = eq %2, 0:i64
+cand %3 1:i1
+
+%0:i32 = var (knownBits=10000000000000000000000000000000)
+%1:i1 = eq 0:i32, %0
+cand %1 0:i1
+
+%0:i128 = var (knownBits=11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111)
+%1:i128 = var (knownBits=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)
+%2:i128 = and %0, %1
+%3:i1 = eq %2, 0:i128
+cand %3 1:i1
+


### PR DESCRIPTION
the RHS, asks souper to synthesize a RHS, and then compares the cost
of the old and new RHSs

to be used in combination with lots of souper optimizations ported
over from Alive

this isn't necessarily quite ready to go (needs some tests for example) but wanted to bring it to Raimondas's attention