### PR TITLE
this change makes the souper parser do stricter checking of constants:

### DIFF
--- a/test/Solver/alive01.opt
+++ b/test/Solver/alive01.opt
@@ -78,9 +78,9 @@ result %r2
 ; %a = xor %x, C
 
 %x:i16 = var
-%a = add %x, 65536
-infer %x
-%r2 = xor %x, 65536
+%a = add %x, -32768
+infer %a
+%r2 = xor %x, -32768
 result %r2
 
 ; Name: AddSub:1098

--- a/test/Solver/alive09.opt
+++ b/test/Solver/alive09.opt
@@ -141,7 +141,7 @@ result %r2
 
 %x:i32 = var
 %t:i16 = trunc %x
-%op0 = eq %t, -234523
+%op0 = eq %t, -2345
 %a1 = and %x, 953400
 %op1 = eq %a1, 3452346
 %r = and %op0, %op1

--- a/test/Solver/alive12.opt
+++ b/test/Solver/alive12.opt
@@ -163,10 +163,10 @@ result %r2
 %x:i32 = var
 %a = and %x, 345234534
 %op0:i8 = trunc %a
-%r = and %op0, 6795033293
+%r = and %op0, 233
 infer %r
 %newcast:i8 = trunc %x
-%r2 = and %newcast, 68
+%r2 = and %newcast, 96
 result %r2
 
 ; Name: AndOrXor:1230  ~A & ~B -> ~(A | B)

--- a/test/Solver/multiple-replacements.opt
+++ b/test/Solver/multiple-replacements.opt
@@ -40,9 +40,9 @@ infer %r
 result %r2
 
 %x:i16 = var
-%a = add %x, 65536
-infer %x
-%r2 = xor %x, 65536
+%a = add %x, -32768
+infer %a
+%r2 = xor %x, -32768
 result %r2
 
 %a:i1 = var

--- a/unittests/Parser/ParserTests.cpp
+++ b/unittests/Parser/ParserTests.cpp
@@ -39,7 +39,7 @@ TEST(ParserTest, Errors) {
       { "%2 = block 111111111111111111111\n",
         "<input>:1:12: 4294967295 is too many block predecessors" },
       { "pc 55555550:i5\n",
-        "<input>:1:15: integer too large for its width" },
+        "<input>:1:15: integer constant is too large for its width" },
       { "%0:i32 = var\n%1:i1 = eq %0:i32, %0:i32\n",
         "<input>:2:12: inst reference may not have a width" },
       { "%0:i1 = eq %1, %1\n", "<input>:1:12: %1 is not an inst" },


### PR DESCRIPTION
we used to just silently truncate whatever value was parsed to the
specified bitwidth, but this masked bugs. now we ensure that the
specified constant con be losslessly converted into the desired
bitwidth.

a slight wrinkle in the plan is that we have examples where "lossless"
depends on signed conversion, and on unsigned conversion, and I don't
know a good way to automatically disambiguate. so the code here checks
if either one works. this doesn't seem satisfying but I don't see a
better answer.