### PR TITLE
this ignore-solver-errors thing was a bad hack, let's get rid of it

### DIFF
--- a/lib/Pass/Pass.cpp
+++ b/lib/Pass/Pass.cpp
@@ -55,10 +55,6 @@ static cl::opt<bool> DynamicProfile("souper-dynamic-profile", cl::init(false),
 static cl::opt<bool> StaticProfile("souper-static-profile", cl::init(false),
     cl::desc("Static profiling of Souper optimizations (default=false)"));
 
-static cl::opt<bool> IgnoreSolverErrors("souper-ignore-solver-errors",
-                                        cl::init(false),
-                                        cl::desc("Ignore solver errors"));
-
 static cl::opt<unsigned> FirstReplace("souper-first-opt", cl::Hidden,
     cl::init(0),
     cl::desc("First Souper optimization to perform (default=0)"));
@@ -227,10 +223,8 @@ public:
       if (std::error_code EC =
           S->infer(Cand.BPCs, Cand.PCs, Cand.Mapping.LHS,
                    Cand.Mapping.RHS, IC)) {
-        if (EC == std::errc::timed_out)
-          continue;
-        if (IgnoreSolverErrors) {
-          llvm::errs() << "Unable to query solver: " + EC.message() + "\n";
+        if (EC == std::errc::timed_out ||
+            EC == std::errc::value_too_large) {
           continue;
         } else {
           report_fatal_error("Unable to query solver: " + EC.message() + "\n");

--- a/utils/sclang.in
+++ b/utils/sclang.in
@@ -70,9 +70,6 @@ optimization found in the current compilation unit and only perform
 those that fall within the range [SOUPER_FIRST_OPT
 .. SOUPER_LAST_OPT], inclusive. Used for debugging Souper
 
-SOUPER_IGNORE_SOLVER_ERRORS -- Keep going when the solver fails, for
-example due to running out of memory or time.
-
 SOUPER_INFER_INT -- Try to synthesize constants.
 
 SOUPER_INFER_NOP -- Try to synthesize nops: Optimizations where the
@@ -213,10 +210,6 @@ if ($souper) {
 
     if (exists $ENV{"SOUPER_INFER_NOP"}) {
       push @ARGV, ("-mllvm", "-souper-infer-nop");
-    }
-
-    if (exists $ENV{"SOUPER_IGNORE_SOLVER_ERRORS"}) {
-        push @ARGV, ("-mllvm", "-souper-ignore-solver-errors");
     }
 
     if (exists $ENV{"SOUPER_STATS"}) {


### PR DESCRIPTION
There was this ignore-solver-errors feature that basically just made sclang continue when the solver hit value_too_large errors (which are benign). But it was annoying to remember to set it and also it made sclang ignore more serious errors. I no longer think this feature was a good idea. Let's explicitly ignore solver timeouts and value_too_large in the pass and make sure other errors get propagated out.