### PR TITLE
Fixed a bug caused by NULL returned from CallInst::getCalledFunction()

### DIFF
--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -489,18 +489,20 @@ Inst *ExprBuilder::build(Value *V) {
           return IC.getInst(Inst::UMulWithOverflow, L->Width+1, {Mul, Overflow});
         }
       }
-    } else if (Call->getCalledFunction() &&
-               TLI->getLibFunc(*Call->getCalledFunction(), Func) && TLI->has(Func)) {
-      switch (Func) {
-        case LibFunc_abs: {
-          Inst *A = get(Call->getOperand(0));
-          Inst *Z = IC.getConst(APInt(A->Width, 0));
-          Inst *NegA = IC.getInst(Inst::SubNSW, A->Width, {Z, A}, /*Available=*/false);
-          Inst *Cmp = IC.getInst(Inst::Slt, 1, {Z, A}, /*Available=*/false);
-          return IC.getInst(Inst::Select, A->Width, {Cmp, A, NegA});
+    } else {
+      Function* F = Call->getCalledFunction();
+      if(F && TLI->getLibFunc(*F, Func) && TLI->has(Func)) {
+        switch (Func) {
+          case LibFunc_abs: {
+            Inst *A = get(Call->getOperand(0));
+            Inst *Z = IC.getConst(APInt(A->Width, 0));
+            Inst *NegA = IC.getInst(Inst::SubNSW, A->Width, {Z, A}, /*Available=*/false);
+            Inst *Cmp = IC.getInst(Inst::Slt, 1, {Z, A}, /*Available=*/false);
+            return IC.getInst(Inst::Select, A->Width, {Cmp, A, NegA});
+          }
+          default:
+            break;
         }
-        default:
-          break;
       }
     }
   }

--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -489,7 +489,8 @@ Inst *ExprBuilder::build(Value *V) {
           return IC.getInst(Inst::UMulWithOverflow, L->Width+1, {Mul, Overflow});
         }
       }
-    } else if (TLI->getLibFunc(*Call->getCalledFunction(), Func) && TLI->has(Func)) {
+    } else if (Call->getCalledFunction() &&
+               TLI->getLibFunc(*Call->getCalledFunction(), Func) && TLI->has(Func)) {
       switch (Func) {
         case LibFunc_abs: {
           Inst *A = get(Call->getOperand(0));

--- a/test/Extractor/pr296.c
+++ b/test/Extractor/pr296.c
@@ -1,0 +1,23 @@
+// REQUIRES: solver
+
+// RUN: clang++ -Xclang -load -Xclang %pass -O2 -std=c++11 -mllvm %solver -emit-llvm -S -o - %s
+
+// Regression test for pull request #296
+void *a;
+class c {
+public:
+  virtual bool aq(void *);
+};
+class d {
+  friend class e;
+  template <typename> void aq() { at()->aq(a); }
+  c *at();
+};
+class e {
+public:
+  static d au() {
+    d b;
+    b.aq<e>();
+  }
+};
+void f() { e::au(); }


### PR DESCRIPTION
According to the source [1], the CallInst::getCalledFunction() returns NULL pointer if callee is not a llvm::Function. This patches fixed the bug where getLibFunc() tries to get the information from a NULL pointer.

[1] http://llvm.org/doxygen/Instructions_8h_source.html#l01873