### PR TITLE
Add a new substitution rule for handling clang++ tests

### DIFF
--- a/test/Extractor/pr296.c
+++ b/test/Extractor/pr296.c
@@ -1,6 +1,6 @@
 // REQUIRES: solver
 
-// RUN: clang++ -Xclang -load -Xclang %pass -O2 -std=c++11 -mllvm %solver -emit-llvm -S -o - %s
+// RUN: %clang++ -Xclang -load -Xclang %pass -O2 -std=c++11 -mllvm %solver -emit-llvm -S -o - %s
 
 // Regression test for pull request #296
 void *a;

--- a/test/Pass/clang-pass.c
+++ b/test/Pass/clang-pass.c
@@ -1,6 +1,6 @@
 // REQUIRES: solver
 
-// RUN: clang -Xclang -load -Xclang %pass -O2 -mllvm %solver -emit-llvm -S -o - %s -mllvm -print-after-all 2>&1 | FileCheck %s
+// RUN: %clang -Xclang -load -Xclang %pass -O2 -mllvm %solver -emit-llvm -S -o - %s -mllvm -print-after-all 2>&1 | FileCheck %s
 
 // Check that peephole passes are registered at least twice.
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -11,8 +11,8 @@ config.test_exec_root = config.builddir + '/test'
 config.excludes = ['Inputs']
 
 config.substitutions.append((r"\bFileCheck\b", config.llvm_bindir + '/FileCheck'))
-config.substitutions.append((r"\bclang\b", config.llvm_bindir + '/clang'))
-config.substitutions.append((r"\bclang\+\+\b", config.llvm_bindir + '/clang++'))
+config.substitutions.append((r"%clang\+\+", config.llvm_bindir + '/clang++'))
+config.substitutions.append((r"%clang", config.llvm_bindir + '/clang'))
 config.substitutions.append((r"\bllvm-as\b", config.llvm_bindir + '/llvm-as'))
 config.substitutions.append((r"\bllvm-dis\b", config.llvm_bindir + '/llvm-dis'))
 config.substitutions.append((r"\bopt\b", config.llvm_bindir + '/opt'))

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -12,6 +12,7 @@ config.excludes = ['Inputs']
 
 config.substitutions.append((r"\bFileCheck\b", config.llvm_bindir + '/FileCheck'))
 config.substitutions.append((r"\bclang\b", config.llvm_bindir + '/clang'))
+config.substitutions.append((r"\bclang\+\+\b", config.llvm_bindir + '/clang++'))
 config.substitutions.append((r"\bllvm-as\b", config.llvm_bindir + '/llvm-as'))
 config.substitutions.append((r"\bllvm-dis\b", config.llvm_bindir + '/llvm-dis'))
 config.substitutions.append((r"\bopt\b", config.llvm_bindir + '/opt'))


### PR DESCRIPTION
I've tested and this rule works correctly. The other clang related (sclang) tests also do the substitute correctly (calls the executables from third_party/llvm).