### PR TITLE
Stop building UB Path conditions for processed blocks

### DIFF
--- a/lib/Extractor/KLEEBuilder.cpp
+++ b/lib/Extractor/KLEEBuilder.cpp
@@ -894,10 +894,10 @@ bool ExprBuilder::getUBPaths(Inst *I, UBPath *Current,
     if (CachedUBPathInsts.count(I))
       return true;
     Current->Insts.push_back(I);
-    // Based on the dependency chain, looks like we would never
-    // encounter this case.
-    assert(!Current->BlockConstraints.count(I->B) &&
-           "Basic block has been added into BlockConstraints!");
+    // Since we treat a select instruction as a phi instruction, it's
+    // possible that I->B has been added already.
+    if (Current->BlockConstraints.count(I->B))
+      return true;
     std::vector<UBPath *> Tmp = { Current };
     // Create copies of the current path
     for (unsigned J = 1; J < Ops.size(); ++J) {

--- a/test/Tool/select-phi-invalid.opt
+++ b/test/Tool/select-phi-invalid.opt
@@ -1,0 +1,16 @@
+; REQUIRES: solver, solver-model
+
+; RUN: %souper-check %solver -infer-rhs -souper-infer-iN %s > %t 2>&1
+; RUN: FileCheck %s < %t
+
+; CHECK: Failed to infer RHS
+
+%0:i32 = var
+%1:i1 = eq 0:i32, %0
+%2 = block 2
+%3:i32 = var
+%4:i32 = phi %2, %3, 1:i32
+%5:i32 = ashr %4, 1:i32
+%6:i32 = or %4, %5
+%7:i32 = select %1, %6, 1:i32
+infer %7

--- a/test/Tool/select-phi.opt
+++ b/test/Tool/select-phi.opt
@@ -1,0 +1,17 @@
+; REQUIRES: solver, solver-model
+
+; RUN: %souper-check %solver -infer-rhs -souper-infer-iN %s > %t 2>&1
+; RUN: FileCheck %s < %t
+
+; CHECK: result 0:i32
+
+%0 = block 2
+%1:i32 = var
+%2:i64 = sext %1
+%3:i64 = phi %0, %2, 0:i64
+%4:i32 = trunc %3
+%5:i1 = ne 0:i32, %4
+%6:i1 = ne 0:i64, %3
+%7:i1 = and %5, %6
+%8:i32 = select %7, 0:i32, %4
+infer %8


### PR DESCRIPTION
Because we treat a select instruction the same way as we do for
a phi instruction, it's possible to revisit a block from
a select instruction. Consequently, our previous assumption
did hold.

This patch fixed the issue 289 and issue 301 by simply returning true
upon re-visiting a block.