### PR TITLE
while looking into the mapping from souper instructions to LLVM values

### DIFF
--- a/include/souper/Extractor/Candidates.h
+++ b/include/souper/Extractor/Candidates.h
@@ -36,27 +36,12 @@ class Value;
 
 namespace souper {
 
-struct InstOrigin {
-  InstOrigin(llvm::Instruction *Inst) : Inst(Inst) {}
-  InstOrigin(llvm::StringRef FunctionName)
-      : Inst(0), FunctionName(FunctionName) {}
-
-  llvm::Instruction *getInstruction() const {
-    return Inst;
-  }
-  std::string getFunctionName() const;
-
-private:
-  llvm::Instruction *Inst;
-  std::string FunctionName;
-};
-
 struct CandidateReplacement {
-  CandidateReplacement(InstOrigin Origin, InstMapping Mapping)
-      : Origin(Origin), Mapping(Mapping) {}
+  CandidateReplacement(llvm::Instruction *Origin, InstMapping Mapping)
+  : Origin(Origin), Mapping(Mapping) {}
 
   /// The instruction from which the candidate was derived.
-  InstOrigin Origin;
+  llvm::Instruction *Origin;
 
   /// The replacement mapping.
   InstMapping Mapping;
@@ -77,8 +62,6 @@ struct CandidateReplacement {
 };
 
 struct BlockCandidateSet {
-  llvm::BasicBlock *Origin;
-
   std::vector<InstMapping> PCs;
   BlockPCs BPCs;
   std::vector<CandidateReplacement> Replacements;

--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -55,21 +55,15 @@ using namespace llvm;
 using namespace klee;
 using namespace souper;
 
-std::string InstOrigin::getFunctionName() const {
-  if (Inst) {
-    const Function *F = Inst->getParent()->getParent();
-    if (F->hasLocalLinkage()) {
-      return (F->getParent()->getModuleIdentifier() + ":" + F->getName()).str();
-    } else {
-      return F->getName();
-    }
-  }
-
-  return FunctionName;
-}
-
 void CandidateReplacement::printFunction(llvm::raw_ostream &Out) const {
-  Out << "; Function: " << Origin.getFunctionName() << '\n';
+  const Function *F = Origin->getParent()->getParent();
+  std::string N;
+  if (F->hasLocalLinkage()) {
+    N = (F->getParent()->getModuleIdentifier() + ":" + F->getName()).str();
+  } else {
+    N = F->getName();
+  }
+  Out << "; Function: " << N << '\n';
 }
 
 void CandidateReplacement::printLHS(llvm::raw_ostream &Out,

--- a/lib/Pass/Pass.cpp
+++ b/lib/Pass/Pass.cpp
@@ -106,7 +106,7 @@ public:
   void dynamicProfile(Function *F, CandidateReplacement &Cand) {
     std::string Str;
     llvm::raw_string_ostream Loc(Str);
-    Instruction *I = Cand.Origin.getInstruction();
+    auto I = Cand.Origin;
     I->getDebugLoc().print(Loc);
     ReplacementContext Context;
     std::string LHS = GetReplacementLHSString(Cand.BPCs, Cand.PCs,
@@ -312,10 +312,9 @@ public:
     for (auto &B : CS.Blocks) {
       for (auto &R : B->Replacements) {
         if (dumpAllReplacements()) {
-          Instruction *I = R.Origin.getInstruction();
           errs() << "\n; *****";
           errs() << "\n; For LLVM instruction:\n;";
-          I->print(errs());
+          R.Origin->print(errs());
           errs() << "\n; Generating replacement:\n";
           ReplacementContext Context;
           PrintReplacementLHS(errs(), R.BPCs, R.PCs, R.Mapping.LHS, Context);
@@ -334,8 +333,7 @@ public:
       if (StaticProfile) {
         std::string Str;
         llvm::raw_string_ostream Loc(Str);
-        Instruction *I = Cand.Origin.getInstruction();
-        I->getDebugLoc().print(Loc);
+        Cand.Origin->getDebugLoc().print(Loc);
         std::string HField = "sprofile " + Loc.str();
         ReplacementContext Context;
         KV->hIncrBy(GetReplacementLHSString(Cand.BPCs, Cand.PCs,
@@ -360,7 +358,7 @@ public:
       if (!Cand.Mapping.RHS)
         continue;
 
-      Instruction *I = Cand.Origin.getInstruction();
+      Instruction *I = Cand.Origin;
       IRBuilder<> Builder(I);
 
       Value *NewVal = getValue(Cand.Mapping.RHS, I, EBC, DT,

--- a/lib/Tool/CandidateMapUtils.cpp
+++ b/lib/Tool/CandidateMapUtils.cpp
@@ -75,7 +75,7 @@ bool SolveCandidateMap(llvm::raw_ostream &OS, CandidateMap &M,
       if (KVForStaticProfile) {
         std::string Str;
         llvm::raw_string_ostream Loc(Str);
-        Instruction *I = Cand.Origin.getInstruction();
+        Instruction *I = Cand.Origin;
         I->getDebugLoc().print(Loc);
         std::string HField = "sprofile " + Loc.str();
         ReplacementContext Context;
@@ -139,7 +139,7 @@ bool CheckCandidateMap(llvm::Module &Mod, CandidateMap &M, Solver *S,
       }
       llvm::APInt ActualVal = Cand.Mapping.RHS->Val;
 
-      llvm::Instruction *Inst = Cand.Origin.getInstruction();
+      llvm::Instruction *Inst = Cand.Origin;
       llvm::MDNode *ExpectedMD = Inst->getMetadata(ExpectedID);
       if (!ExpectedMD) {
         llvm::errs() << "instruction:\n";
@@ -151,6 +151,7 @@ bool CheckCandidateMap(llvm::Module &Mod, CandidateMap &M, Solver *S,
         OK = false;
         continue;
       }
+
       if (ExpectedMD->getNumOperands() != 1 ||
           !mdconst::hasa<ConstantInt>(ExpectedMD->getOperand(0))) {
         llvm::errs() << "instruction:\n";


### PR DESCRIPTION
today, I noticed that the InstOrigin class was useless; this PR
removes it

also, the Origin field of BlockCandidateSet was unused, so we're
removing that as well