### PR TITLE
The question is: how do we (in the pass) remember that mapping from

### DIFF
--- a/include/souper/Extractor/Candidates.h
+++ b/include/souper/Extractor/Candidates.h
@@ -95,7 +95,6 @@ struct BlockInfo {
 struct ExprBuilderContext {
   std::map<const llvm::Value *, Inst *> InstMap;
   std::map<llvm::BasicBlock *, BlockInfo> BlockMap;
-  std::multimap<Inst *, llvm::Value *> Origins;
 };
 
 FunctionCandidateSet ExtractCandidatesFromPass(

--- a/include/souper/Inst/Inst.h
+++ b/include/souper/Inst/Inst.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FoldingSet.h"
+#include "llvm/IR/Value.h"
 #include <map>
 #include <memory>
 #include <set>
@@ -113,9 +114,11 @@ struct Inst : llvm::FoldingSetNode {
   std::string Name;
   std::vector<Inst *> Ops;
   mutable std::vector<Inst *> OrderedOps;
+  std::vector<llvm::Value *> Origins;
 
   bool operator<(const Inst &I) const;
   const std::vector<Inst *> &orderedOps() const;
+  bool hasOrigin(llvm::Value *V) const;
 
   void Profile(llvm::FoldingSetNodeID &ID) const;
 

--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -20,6 +20,10 @@
 
 using namespace souper;
 
+bool Inst::hasOrigin(llvm::Value *V) const {
+  return std::find(Origins.begin(), Origins.end(), V) != Origins.end();
+}
+
 bool Inst::operator<(const Inst &Other) const {
   if (this == &Other)
     return false;

--- a/test/Pass/replace-replacement.ll
+++ b/test/Pass/replace-replacement.ll
@@ -1,0 +1,24 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as -o %t %s
+; RUN: %opt -load %pass -souper %solver -souper-infer-nop -souper-stress-nop -S -stats -o - %s 2>&1 | %FileCheck %s
+
+; CHECK: store i32 %cond.i
+
+@a = common global i32 0, align 4
+@c = common global i32 0, align 4
+@b = common global i32 0, align 4
+
+define void @f() local_unnamed_addr #0 {
+entry:
+  %0 = load i32, i32* @a, align 4
+  %tobool.i = icmp eq i32 %0, 0
+  %cond.i = select i1 %tobool.i, i32 0, i32 -1
+  store i32 %cond.i, i32* @c, align 4
+  %shl.i = shl nsw i32 %cond.i, 2
+  %or.i = or i32 %cond.i, %shl.i
+  %shl1.i = shl nsw i32 %cond.i, 8
+  %or2.i = or i32 %or.i, %shl1.i
+  store i32 %or2.i, i32* @b, align 4
+  ret void
+}


### PR DESCRIPTION
Souper instructions to LLVM instructions?

From early in, souper has maintained an Origin pointer as part of the
mapping. In other words, a mapping from LHS or RHS remembers which
LLVM instruction is getting replaced. This worked only as long as we
were synthesizing constant, it does not support more interesting
replacements.

Later, I added an Origins multimap to the expression builder context
object which tracked the LLVM origin of every Souper instruction in
that context; this suffices to support replacements based on full
synthesis. However, just lately it became a pain because we've started
(for multiple reasons) making copies of souper instructions, which
required updating the Origins multimap, resulting in overhead when
many copies were made.

So this PR stores origins in the Inst class, avoiding the need to
update an external map when we copy instructions. I was hoping this
would support removing the Origin part of the Mapping, but I've left
that intact since it remembers the single origin for that mapping,
whereas the instruction may have multiple origins.

Finally, the Pass has a separate map to track origins for instructions
that have already been replaced in this run of the pass -- we want to
avoid adding uses of those. The new test case for this PR triggers
that behavior: Souper performs a nop and then a second nop wants to
refer to the first one, and this gets forwarded to the RHS of the
first replacement.