### PR TITLE
Handling values with external uses

### DIFF
--- a/include/souper/Inst/Inst.h
+++ b/include/souper/Inst/Inst.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace souper {
@@ -112,6 +113,7 @@ struct Inst : llvm::FoldingSetNode {
   bool Available = true;
   llvm::APInt Val;
   std::string Name;
+  std::unordered_set<Inst *> DepsWithExternalUses;
   std::vector<Inst *> Ops;
   mutable std::vector<Inst *> OrderedOps;
   std::vector<llvm::Value *> Origins;
@@ -169,6 +171,7 @@ class ReplacementContext {
   llvm::DenseMap<Block *, std::string> BlockNames;
   std::map<std::string, Inst *> NameToInst;
   std::map<std::string, Block *> NameToBlock;
+  std::string printInstImpl(Inst *I, llvm::raw_ostream &Out, bool printNames, Inst *OrigI);
 
 public:
   void printPCs(const std::vector<InstMapping> &PCs,

--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -105,6 +105,7 @@ struct ExprBuilder {
                          std::unordered_set<Block *> &VisitedBlocks,
                          BasicBlock *BB);
   Inst *get(Value *V);
+  void markExternalUses(Inst *I);
 };
 
 }
@@ -214,6 +215,31 @@ Inst *ExprBuilder::buildGEP(Inst *Ptr, gep_type_iterator begin,
     }
   }
   return Ptr;
+}
+
+void ExprBuilder::markExternalUses (Inst *I) {
+  std::map<Inst *, unsigned> UsesCount;
+  std::vector<Inst *> Stack;
+  Stack.push_back(I);
+  while(!Stack.empty()) {
+    Inst* T = Stack.back();
+    Stack.pop_back();
+    if (I != T) {
+      if (UsesCount.find(T) == UsesCount.end())
+        UsesCount[T] = 1;
+      else
+        UsesCount[T]++;
+    }
+    for (auto Op: T->Ops) {
+      if (Op->K != Inst::Const && Op->K != Inst::Var
+          && Op->K != Inst::UntypedConst && Op->K != Inst::Phi)
+        Stack.push_back(Op);
+    }
+  }
+  for (auto U : UsesCount)
+    for (auto R : EBC.InstMap)
+      if (R.second == U.first && R.first->getNumUses() != U.second)
+        I->DepsWithExternalUses.insert(U.first);
 }
 
 Inst *ExprBuilder::build(Value *V) {
@@ -738,7 +764,9 @@ void ExtractExprCandidates(Function &F, const LoopInfo *LI, DemandedBits *DB,
     std::unique_ptr<BlockCandidateSet> BCS(new BlockCandidateSet);
     for (auto &I : BB) {
       if (I.getType()->isIntegerTy()) {
-        BCS->Replacements.emplace_back(&I, InstMapping(EB.get(&I), 0));
+        Inst *In = EB.get(&I);
+        EB.markExternalUses(In);
+        BCS->Replacements.emplace_back(&I, InstMapping(In, 0));
         assert(EB.get(&I)->hasOrigin(&I));
       }
     }

--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -92,6 +92,12 @@ const std::vector<Inst *> &Inst::orderedOps() const {
 
 std::string ReplacementContext::printInst(Inst *I, llvm::raw_ostream &Out,
                                           bool printNames) {
+  return printInstImpl(I, Out, printNames, I);
+}
+
+std::string ReplacementContext::printInstImpl(Inst *I, llvm::raw_ostream &Out,
+                                              bool printNames, Inst *OrigI) {
+
   std::string Str;
   llvm::raw_string_ostream SS(Str);
 
@@ -131,7 +137,7 @@ std::string ReplacementContext::printInst(Inst *I, llvm::raw_ostream &Out,
       OpsSS << ", ";
     switch (I->K) {
       default:
-        OpsSS << printInst(Ops[Idx], Out, printNames);
+        OpsSS << printInstImpl(Ops[Idx], Out, printNames, OrigI);
         break;
       case Inst::SAddWithOverflow:
       case Inst::UAddWithOverflow:
@@ -139,7 +145,7 @@ std::string ReplacementContext::printInst(Inst *I, llvm::raw_ostream &Out,
       case Inst::USubWithOverflow:
       case Inst::SMulWithOverflow:
       case Inst::UMulWithOverflow:
-        OpsSS << printInst(I->Ops[1]->Ops[Idx], Out, printNames);
+        OpsSS << printInstImpl(I->Ops[1]->Ops[Idx], Out, printNames, OrigI);
         break;
     }
   }
@@ -177,6 +183,10 @@ std::string ReplacementContext::printInst(Inst *I, llvm::raw_ostream &Out,
           Out << " (signBits=" << I->NumSignBits << ")";
       }
       Out << OpsSS.str();
+
+      if (OrigI->DepsWithExternalUses.find(I) != OrigI->DepsWithExternalUses.end())
+        Out << " (hasExternalUses)";
+
       if (printNames && !I->Name.empty())
         Out << " ; " << I->Name;
       Out << '\n';


### PR DESCRIPTION
I have just upload a commit for external use tagging support for Souper candidate extractor. This is the very first stage of this Pull Request. Here are the details:

I've added a new std::set<Inst *> field called DepsWithExternalUses to Inst. This set stores any ancestor Insts with external uses for that Inst.

I've also added a markExternalUses function. The function takes an Inst and fills the DepsWithExternalUses for that Inst. The algorithm works as follows: First count the number of uses in Souper IR for each ancestor Insts. Then compare the number with the use number in original LLVM IR. If they're different,  we can conclude that the value in LLVM must have external uses, and we insert the corresponding Inst to DepsWithExternalUses.

I've also added a printInstWithExtUsesAnnotations function. This function is an alternative Inst printer and it adds the external tagging to its output. This function will be merged to printInst function later.

Given a input program:
```llvm
define i32 @foo(i32 %x) {
entry:
  %a = add i32 %x, 1
  store i32 %a, i32* @amem, align 4
  %b = add i32 %a, 1
  store i32 %b, i32* @bmem, align 4
  %c = mul i32 %b, 2
  store i32 %c, i32* @cmem, align 4
  %d = add i32 %c, 1
  ret i32 %d
}
```
The printInstWithExtUsesAnnotations will print the following Souper Inst for %d,
```
%0:i32 = var
%1:i32 = add 1:i32, %0 (hasExternalUses)
%2:i32 = add 1:i32, %1 (hasExternalUses)
%3:i32 = mul 2:i32, %2 (hasExternalUses)
%4:i32 = add 1:i32, %3
```