### PR TITLE
first cut at providing synthesis with 'big components' from the LHS

### DIFF
--- a/include/souper/Infer/InstSynthesis.h
+++ b/include/souper/Infer/InstSynthesis.h
@@ -132,6 +132,9 @@ public:
                              const BlockPCs &BPCs,
                              const std::vector<InstMapping> &PCs,
                              Inst *TargetLHS, Inst *&RHS,
+                             const std::vector<Inst *> &Copies,
+                             const std::vector<InstMapping> &PCsCopy,
+                             const BlockPCs &BPCsCopy,
                              InstContext &IC, unsigned Timeout);
 
 private:

--- a/lib/Infer/InstSynthesis.cpp
+++ b/lib/Infer/InstSynthesis.cpp
@@ -59,6 +59,9 @@ std::error_code InstSynthesis::synthesize(SMTLIBSolver *SMTSolver,
                                           const BlockPCs &BPCs,
                                           const std::vector<InstMapping> &PCs,
                                           Inst *TargetLHS, Inst *&RHS,
+                                          const std::vector<Inst *> &Copies,
+                                          const std::vector<InstMapping> &PCsCopy,
+                                          const BlockPCs &BPCsCopy,
                                           InstContext &IC, unsigned Timeout) {
   std::error_code EC;
 


### PR DESCRIPTION
Ok, this is a work in progress for Raimondas to look at.

this PR adds parameters to instruction synthesis corresponding to a vector of instructions from the LHS that can be used as components in synthesis. just like in nop synthesis, these have been separated out from each other (and from the RHS) to avoid unsoundness due to component reuse.

also like nop synthesis, these components are found using DFS starting at the root of the LHS, based on the hypothesis that these are the most useful things to use. these should be used instead of vars in synthesis.

the number of big components is currently set to the same value as MaxNops which defaults to 20. of course we can use whatever value we want here.