### PR TITLE
Build script improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_program(LLVM_CONFIG_EXECUTABLE HINTS ${CMAKE_SOURCE_DIR}/third_party/llvm/${CMAKE_BUILD_TYPE}/bin
+                                    HINTS ${CMAKE_LLVM_INSTALL_DIR}/bin
                                     NAMES llvm-config DOC "llvm-config executable")
 if(LLVM_CONFIG_EXECUTABLE STREQUAL "LLVM_CONFIG_EXECUTABLE-NOTFOUND")
   message(FATAL_ERROR "llvm-config could not be found!")

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ add build_deps.sh /usr/src/souper/build_deps.sh
 add clone_and_test.sh /usr/src/souper/clone_and_test.sh
 
 run cd /usr/src/souper \
-#	&& ./build_deps.sh Debug \
+#	&& ./build_deps.sh --llvm-build-type=Debug \
 #       && rm -rf third_party/llvm/Debug-build \
-	&& ./build_deps.sh Release \
+	&& ./build_deps.sh --llvm-build-type=Release \
         && rm -rf third_party/llvm/Release-build \
 	&& rm -rf third_party/hiredis/install/lib/libhiredis.so*
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ $ go get github.com/garyburd/redigo/redis
 
 1. Download and build dependencies:
 ```
-$ ./build_deps.sh $buildtype $extra_cmake_flags
+$ ./build_deps.sh <options>
 ```
-   $buildtype is optional; it defaults to Release and may be set to any LLVM
-   build type.
-   $extra_cmake_flags is optional. It is passed to CMake.
+   See ./build_deps.sh --help for various optios.
 
 2. Run CMake from a build directory:
 ```
@@ -40,6 +38,12 @@ $ cmake -DCMAKE_BUILD_TYPE=$buildtype /path/to/souper
    to run Souper's full test suite, add this option to CMake (with the
    appropriate solver and path to the solver executable):
    -DTEST_SOLVER="-z3-path=/usr/bin/z3"
+
+   If you have used custom path for LLVM build and installed the
+   binaries in a non-standard location, you must mention following
+   option to CMake so that it can find the appropriate binaries during build time:
+
+   `-DCMAKE_LLVM_INSTALL_DIR=/your/custom/location/`
 
 3. Run 'make' from the build directory.
 
@@ -55,8 +59,9 @@ literals. You should build Souper using GCC 4.9+ or Clang.
 
 After following the above instructions, you will have a Souper
 executable in /path/to/souper-build/souper and a Clang executable in
-/path/to/souper/third_party/llvm/$buildtype/bin/clang.  You can use the
-Clang executable to create an LLVM bitcode file like this:
+your LLVM install directory (defaults to
+/path/to/souper/third_party/llvm/$buildtype/bin/clang).
+You can use the Clang executable to create an LLVM bitcode file like this:
 ```
 $ /path/to/clang -emit-llvm -c -o /path/to/file.bc /path/to/file.c
 ```

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -170,12 +170,22 @@ set -e
 mkdir -p $llvm_builddir
 cmake_flags="$llvm_dir -DCMAKE_INSTALL_PREFIX=$llvm_installdir -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=$llvm_build_type -DCMAKE_CXX_FLAGS=-DLLVM_ENABLE_STATS=true"
 
+# Whether to configure the project using cmake or not.
+cmake_generate=true;
+if [ -d $llvm_builddir/CMakeFiles ]; then
+  cmake_generate=false;
+fi
+
 if [ -n "`which ninja`" ] ; then
-  (cd $llvm_builddir && cmake -G Ninja $cmake_flags "$@")
+  if [ "$cmake_generate" = true ]; then
+    (cd $llvm_builddir && cmake -G Ninja $cmake_flags "$@")
+  fi
   ninja -C $llvm_builddir
   ninja -C $llvm_builddir install
 else
-  (cd $llvm_builddir && cmake $cmake_flags "$@")
+  if [ "$cmake_generate" = true ]; then
+    (cd $llvm_builddir && cmake $cmake_flags "$@")
+  fi
   make -C $llvm_builddir -j4
   make -C $llvm_builddir -j4 install
 fi

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -14,32 +14,117 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -d "third_party" ]; then
-  echo "Directory third_party exists, remove this directory before running build_deps.sh."
-  exit 1;
-fi
-
 # hiredis version 0.13.3
 hiredis_commit=010756025e8cefd1bc66c6d4ed3b1648ef6f1f95
 llvm_branch=tags/RELEASE_600/final
 klee_repo=https://github.com/rsas/klee
 klee_branch=pure-bv-qf-llvm-6.0-patch
 
+llvm_dir=$(pwd)/third_party/llvm
 llvm_build_type=Release
-if [ -n "$1" ] ; then
-  llvm_build_type="$1"
-  shift
+llvm_installdir=$llvm_dir/$llvm_build_type
+llvm_builddir=$llvm_dir/${llvm_build_type}-build
+llvm_update_repos=false;
+
+print_help ()
+{
+    echo "Usage: ./build_dep.sh [OPTIONS]"
+    echo "Builds dependencies"
+    echo ""
+    echo "    --llvm-build-type=<type>  Defaults to Release; can be any of the LLVM build type."
+    echo "    --llvm-dir=<path>         Path to LLVM source."
+    echo "    --llvm-build-dir=<path>   LLVM build directory. Should be mentioned after --llvm-dir."
+    echo "    --llvm-install-dir=<path> LLVM installation directory. Should be mentioned after --llvm-dir."
+    echo "    --llvm-branch=<branch>    Can be set to any branch in LLVM source."
+    echo "    --update                  If mentioned, the existing LLVM sources (pointed to by --llvm-dir) are updated."
+    echo "    --help                    Prints this help."
+    exit 0
+}
+
+# Check for command line arguments
+for i in "$@"
+do
+    case $i in
+	--llvm-build-type=*)
+	    llvm_build_type="${i#=*}";
+	    shift
+	    ;;
+	--llvm-dir=*)
+	    llvm_dir="${i#*=}";
+
+	    # Set the default builddir and installdir for custom llvm_dir
+	    llvm_builddir=$llvm_dir/${llvm_build_type}-build;
+	    llvm_installdir=$llvm_dir/$llvm_build_type;
+	    shift
+	    ;;
+	--llvm-install-dir=*)
+	    llvm_installdir="${i#*=}";
+	    shift
+	    ;;
+	--llvm-build-dir=*)
+	    llvm_builddir="${i#*=}";
+	    shift
+	    ;;
+	--llvm-branch=*)
+	    llvm_branch="${i#*=}";
+	    shift
+	    ;;
+	--update)
+	    llvm_update_repos=true;
+	    shift
+	    ;;
+	--help)
+	    print_help
+	    ;;
+	-*)
+	    ;; # ignore
+    esac
+done
+
+if [ -d "third_party" ]; then
+    echo "Directory third_party exists, remove this directory before running build_deps.sh."
+    exit 1;
 fi
 
-llvmdir=third_party/llvm
-llvm_installdir=$(pwd)/$llvmdir/$llvm_build_type
-llvm_builddir=$(pwd)/$llvmdir/${llvm_build_type}-build
+llvm_clang_dir=$llvm_dir/tools/clang
+llvm_compilerrt_dir=$llvm_dir/projects/compiler-rt
 
-svn co https://llvm.org/svn/llvm-project/llvm/${llvm_branch} $llvmdir
-svn co https://llvm.org/svn/llvm-project/cfe/${llvm_branch} $llvmdir/tools/clang
-svn co https://llvm.org/svn/llvm-project/compiler-rt/${llvm_branch} $llvmdir/projects/compiler-rt
+if [ -d "$llvm_dir/.svn" ]; then
+    echo "LLVM sources ($llvm_dir) already exists."
+    if [ "$llvm_update_repos" = true ]; then
+	cd $llvm_dir && svn update && cd -;
+    fi
+else
+    echo "LLVM sources ($llvm_dir) do not exist. Cloning..."
+    svn co https://llvm.org/svn/llvm-project/llvm/${llvm_branch} $llvm_dir
+fi
+
+if [ -d "$llvm_clang_dir/.svn" ]; then
+    echo "clang sources ($llvm_clang_dir) already exists."
+    if [ "$llvm_update_repos" = true ]; then
+	cd $llvm_clang_dir && svn update && cd -;
+    fi
+else
+    echo "clang sources ($llvm_clang_dir) do not exist. Cloning..."
+    svn co https://llvm.org/svn/llvm-project/cfe/${llvm_branch} $llvm_clang_dir
+fi
+
+if [ -d "$llvm_compilerrt_dir/.svn" ]; then
+    echo "compiler-rt sources ($llvm_compilerrt_dir) already exists."
+    if [ "$llvm_update_repos" = true ]; then
+	cd $llvm_compilerrt_dir && svn update && cd -;
+    fi
+else
+    echo "compiler-rt sources ($llvm_compilerrt_dir) do not exist. Cloning..."
+    svn co https://llvm.org/svn/llvm-project/compiler-rt/${llvm_branch} $llvm_compilerrt_dir
+fi
+
+# Patch command may fail in some cases. Eg: when the patch is already applied.
+# Don't exit immediately in such cases
+set +e
+
 # Disable the broken select -> logic optimizations
-cat <<EOF | patch $llvmdir/lib/Transforms/InstCombine/InstCombineSelect.cpp
+cat <<EOF | patch $llvm_dir/lib/Transforms/InstCombine/InstCombineSelect.cpp
 --- lib/Transforms/InstCombine/InstCombineSelect.cpp    (revision 326856)
 +++ lib/Transforms/InstCombine/InstCombineSelect.cpp    (working copy)
 @@ -1334,7 +1334,7 @@
@@ -78,9 +163,12 @@ cat <<EOF | patch $llvmdir/lib/Transforms/InstCombine/InstCombineSelect.cpp
    // See if we are selecting two values based on a comparison of the two values.
    if (FCmpInst *FCI = dyn_cast<FCmpInst>(CondVal)) {
 EOF
-mkdir -p $llvm_builddir
 
-cmake_flags=".. -DCMAKE_INSTALL_PREFIX=$llvm_installdir -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=$llvm_build_type -DCMAKE_CXX_FLAGS=-DLLVM_ENABLE_STATS=true"
+# Restore
+set -e
+
+mkdir -p $llvm_builddir
+cmake_flags="$llvm_dir -DCMAKE_INSTALL_PREFIX=$llvm_installdir -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=$llvm_build_type -DCMAKE_CXX_FLAGS=-DLLVM_ENABLE_STATS=true"
 
 if [ -n "`which ninja`" ] ; then
   (cd $llvm_builddir && cmake -G Ninja $cmake_flags "$@")
@@ -100,7 +188,7 @@ cp $llvm_builddir/lib/libgtest.a $llvm_installdir/lib
 
 kleedir=third_party/klee
 
-if [ -d third_party/klee/.git ] ; then
+if [ -d $kleedir/.git ] ; then
   (cd $kleedir && git fetch)
 else
   git clone -b $klee_branch $klee_repo $kleedir


### PR DESCRIPTION
In the earlier setup, the ./build_deps.sh was cloning and building LLVM in third_party/ directory unconditionally. This can be {time,space}-consuming when you already have a LLVM build in your machine. Let's Introduce some flags to the script to mention the custom LLVM build. This solves the problem for me (and hopefully will help others as well).

Also, no need to run cmake again in the build script, if it was already run before.

