### PR TITLE
Added commandline option for turning off instruction combiner

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -40,6 +40,9 @@ svn co https://llvm.org/svn/llvm-project/cfe/${llvm_branch} $llvmdir/tools/clang
 svn co https://llvm.org/svn/llvm-project/compiler-rt/${llvm_branch} $llvmdir/projects/compiler-rt
 # Disable the broken select -> logic optimizations
 patch $llvmdir/lib/Transforms/InstCombine/InstCombineSelect.cpp < patches/disable-instcombine-select-to-logic.patch
+# Apply instcombine switch patch
+patch -d $llvmdir -p0 -i $(pwd)/patches/enable-instcombine-switch.patch
+
 mkdir -p $llvm_builddir
 
 cmake_flags=".. -DCMAKE_INSTALL_PREFIX=$llvm_installdir -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=$llvm_build_type"

--- a/patches/enable-instcombine-switch.patch
+++ b/patches/enable-instcombine-switch.patch
@@ -1,0 +1,24 @@
+Index: lib/Transforms/InstCombine/InstructionCombining.cpp
+===================================================================
+--- lib/Transforms/InstCombine/InstructionCombining.cpp	(revision 342671)
++++ lib/Transforms/InstCombine/InstructionCombining.cpp	(working copy)
+@@ -127,6 +127,10 @@
+ MaxArraySize("instcombine-maxarray-size", cl::init(1024),
+              cl::desc("Maximum array size considered when doing a combine"));
+ 
++static cl::opt<bool>
++DisableInstructionCombiner("disable-instruction-combiner", cl::init(false),
++                           cl::desc("Disable InstCombine Pass (default = off)"));
++
+ // FIXME: Remove this flag when it is no longer necessary to convert
+ // llvm.dbg.declare to avoid inaccurate debug info. Setting this to false
+ // increases variable availability at the cost of accuracy. Variables that
+@@ -3249,6 +3253,8 @@
+     AssumptionCache &AC, TargetLibraryInfo &TLI, DominatorTree &DT,
+     OptimizationRemarkEmitter &ORE, bool ExpensiveCombines = true,
+     LoopInfo *LI = nullptr) {
++  if (DisableInstructionCombiner)
++    return false;
+   auto &DL = F.getParent()->getDataLayout();
+   ExpensiveCombines |= EnableExpensiveCombines;
+ 

--- a/utils/sclang.in
+++ b/utils/sclang.in
@@ -108,6 +108,9 @@ SOUPER_STATIC_PROFILE -- During compilation, communicate with a running
 Redis instance in order to record the number of times each optimization
 was performed.
 
+LLVM_DISABLE_INSTRUCTION_COMBINER -- Disable the invocation of instruction
+combiner during compilation.
+
 SOUPER_STATS -- Ask LLVM to print statistics.
 
 EOF
@@ -220,6 +223,9 @@ if ($souper) {
     }
     if (exists $ENV{"SOUPER_HARVEST_DEMANDED_BITS"}) {
         push @ARGV, ("-mllvm", "-souper-harvest-demanded-bits");
+    }
+    if (exists $ENV{"LLVM_DISABLE_INSTRUCTION_COMBINER"}) {
+        push @ARGV, ("-mllvm", "-disable-instruction-combiner");
     }
 }
 


### PR DESCRIPTION
With this patch one may call llvm opt with "-disable-instruction-combiner", to disable the instruction combiner during the optimization. For clang/clang++, call with '-m -disable-instruction-combiner'.

Also the sclang is updated. Setting environment variable "LLVM_DISABLE_INSTRUCTION_COMBINER" will also turn off the instcombine.