### PR TITLE
Bootstrap LLVM with Ubuntu pre-build clang, solve the go cache issue …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ run set -x; \
         apt-get update -qq \
         && apt-get remove -y -qq clang llvm llvm-runtime \
 	&& apt-get install libgmp10 \
-	&& echo 'ca-certificates gcc g++ valgrind libc6-dev libgmp-dev cmake patch ninja-build make autoconf automake libtool golang-go python subversion git clang' > /usr/src/build-deps \
+	&& echo 'ca-certificates valgrind libc6-dev libgmp-dev cmake patch ninja-build make autoconf automake libtool golang-go python subversion git clang' > /usr/src/build-deps \
 	&& apt-get install -y $(cat /usr/src/build-deps) --no-install-recommends \
 	&& git clone https://github.com/Z3Prover/z3.git /usr/src/z3 \
 	&& git clone https://github.com/antirez/redis /usr/src/redis
@@ -28,7 +28,8 @@ add build_deps.sh /usr/src/souper/build_deps.sh
 add clone_and_test.sh /usr/src/souper/clone_and_test.sh
 add patches /usr/src/souper/patches
 
-run cd /usr/src/souper \
+run export CC=clang CXX=clang++ \
+	&& cd /usr/src/souper \
 #	&& ./build_deps.sh Debug \
 #       && rm -rf third_party/llvm/Debug-build \
 	&& ./build_deps.sh Release \
@@ -56,7 +57,7 @@ run export GOPATH=/usr/src/go \
         && rm -rf /usr/src/souper-build \
 	&& strip /usr/local/bin/* \
 	&& groupadd -r souper \
-	&& useradd -r -g souper souper \
+	&& useradd -m -r -g souper souper \
 	&& mkdir /data \
 	&& chown souper:souper /data \
 	&& rm -rf /usr/local/include /usr/local/lib/*.a /usr/local/lib/*.la

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -47,11 +47,6 @@ mkdir -p $llvm_builddir
 
 cmake_flags=".. -DCMAKE_INSTALL_PREFIX=$llvm_installdir -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=$llvm_build_type"
 
-# Use clang if available
-if [ -n "`which clang`" ] && [ -n "`which clang++`" ] ; then
-  cmake_flags="$cmake_flags -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang"
-fi
-
 if [ -n "`which ninja`" ] ; then
   (cd $llvm_builddir && cmake -G Ninja $cmake_flags "$@")
   ninja -C $llvm_builddir

--- a/clone_and_test.sh
+++ b/clone_and_test.sh
@@ -41,7 +41,7 @@ SRCDIR="$PWD"
 
 mkdir build-release
 cd build-release
-cmake -G Ninja -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_FLAGS='-Werror' -DTEST_SOLVER=-z3-path=$Z3 -DTEST_SYNTHESIS=ON -DCMAKE_BUILD_TYPE=Release ..
+PATH=/usr/src/souper/third_party/llvm/Release/bin:$PATH cmake -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_FLAGS='-Werror' -DTEST_SOLVER=-z3-path=$Z3 -DTEST_SYNTHESIS=ON -DCMAKE_BUILD_TYPE=Release ..
 ninja
 LIT_ARGS="-v -vv" ./run_lit
 #LIT_ARGS="-v -vv --vg --vg-arg=--trace-children-skip=$Z3 --vg-arg=--suppressions=$SRCDIR/valgrind.supp" ./run_lit


### PR DESCRIPTION
…and use bootstrapped clang only for Souper test builds.