### PR TITLE
build libcxx and libcxxabi by default in build_deps.sh

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -38,6 +38,8 @@ llvm_builddir=$(pwd)/$llvmdir/${llvm_build_type}-build
 svn co https://llvm.org/svn/llvm-project/llvm/${llvm_branch} $llvmdir
 svn co https://llvm.org/svn/llvm-project/cfe/${llvm_branch} $llvmdir/tools/clang
 svn co https://llvm.org/svn/llvm-project/compiler-rt/${llvm_branch} $llvmdir/projects/compiler-rt
+svn co https://llvm.org/svn/llvm-project/libcxx/${llvm_branch} $llvmdir/projects/libcxx
+svn co https://llvm.org/svn/llvm-project/libcxxabi/${llvm_branch} $llvmdir/projects/libcxxabi
 # Disable the broken select -> logic optimizations
 patch $llvmdir/lib/Transforms/InstCombine/InstCombineSelect.cpp < patches/disable-instcombine-select-to-logic.patch
 # Apply instcombine switch patch


### PR DESCRIPTION
Souper build crashes when building with the third_party LLVM on Mac OS X. A LLVM build with libcxx and libcxxabi solves the crash. This PR forces building libcxx.