### PR TITLE
Generate new input guesses for each constant synthesis try

### DIFF
--- a/test/Pass/alive0.ll
+++ b/test/Pass/alive0.ll
@@ -12,7 +12,7 @@ define i32 @alive0_0(i32, i32) local_unnamed_addr #0 {
   ;CHECK-NOT: %Op0 = or i32 %0, %1
   ;CHECK-NOT: %Op1 = xor i32 %0, %1
   ;CHECK-NOT: %r = sub i32 %Op0, %Op1
-  ;CHECK: %3 = and i32 %0, %1
+  ;CHECK: %3 = and i32 {{(%0, %1)|(%1, %0)}}
 
 }
 


### PR DESCRIPTION
This patch reduces the number of constant synthesis tries required for the following program from 175 to 82

```
%in:i16 = var
%x = add %in, 25245
%a = lshr %x, 1
%b = shl %a, 2
%c = lshr %b, 1
infer %c
```