### PR TITLE
Multiple RHS Support

### DIFF
--- a/include/souper/Extractor/Solver.h
+++ b/include/souper/Extractor/Solver.h
@@ -30,11 +30,11 @@ class Solver {
 public:
   virtual ~Solver();
   virtual std::error_code
-  infer(const BlockPCs &BPCs, const std::vector<InstMapping> &PCs, 
-        Inst *LHS, Inst *&RHS, InstContext &IC) = 0;
+  infer(const BlockPCs &BPCs, const std::vector<InstMapping> &PCs,
+        Inst *LHS, std::vector<Inst *> &RHSs, InstContext &IC) = 0;
   virtual std::error_code
   isValid(InstContext &IC, const BlockPCs &BPCs,
-          const std::vector<InstMapping> &PCs, 
+          const std::vector<InstMapping> &PCs,
           InstMapping Mapping, bool &IsValid,
           std::vector<std::pair<Inst *, llvm::APInt>> *Model) = 0;
   virtual std::string getName() = 0;

--- a/include/souper/Infer/ExhaustiveSynthesis.h
+++ b/include/souper/Infer/ExhaustiveSynthesis.h
@@ -30,7 +30,7 @@ public:
   std::error_code synthesize(SMTLIBSolver *SMTSolver,
                              const BlockPCs &BPCs,
                              const std::vector<InstMapping> &PCs,
-                             Inst *TargetLHS, Inst *&RHS,
+                             Inst *TargetLHS, std::vector<Inst *> &RHS,
                              InstContext &IC, unsigned Timeout);
 
 };

--- a/lib/Pass/Pass.cpp
+++ b/lib/Pass/Pass.cpp
@@ -399,9 +399,10 @@ public:
         Changed = true;
         continue;
       }
+      std::vector<Inst *> RHSs;
       if (std::error_code EC =
           S->infer(Cand.BPCs, Cand.PCs, Cand.Mapping.LHS,
-                   Cand.Mapping.RHS, IC)) {
+                   RHSs, IC)) {
         if (EC == std::errc::timed_out ||
             EC == std::errc::value_too_large) {
           continue;
@@ -409,6 +410,7 @@ public:
           report_fatal_error("Unable to query solver: " + EC.message() + "\n");
         }
       }
+      Cand.Mapping.RHS = RHSs.empty() ? 0 : RHSs.front();
       if (!Cand.Mapping.RHS)
         continue;
 

--- a/lib/Tool/CandidateMapUtils.cpp
+++ b/lib/Tool/CandidateMapUtils.cpp
@@ -83,16 +83,16 @@ bool SolveCandidateMap(llvm::raw_ostream &OS, CandidateMap &M,
             Cand.PCs, Cand.Mapping.LHS, Context), HField, 1);
       }
 
-      Inst *RHS;
+      std::vector<Inst *> RHSs;
       if (std::error_code EC =
-              S->infer(Cand.BPCs, Cand.PCs, Cand.Mapping.LHS, RHS, IC)) {
+          S->infer(Cand.BPCs, Cand.PCs, Cand.Mapping.LHS, RHSs, IC)) {
         llvm::errs() << "Unable to query solver: " << EC.message() << '\n';
         return false;
       }
-      if (RHS) {
+      if (!RHSs.empty()) {
         OS << '\n';
         OS << "; Static profile " << Profile[I] << '\n';
-        Cand.Mapping.RHS = RHS;
+        Cand.Mapping.RHS = RHSs.front();
         Cand.printFunction(OS);
         Cand.print(OS);
       }
@@ -121,14 +121,14 @@ bool CheckCandidateMap(llvm::Module &Mod, CandidateMap &M, Solver *S,
 
   bool OK = true;
   for (auto &Cand : M) {
-    Inst *RHS;
+    std::vector<Inst *> RHSs;
     if (std::error_code EC =
-            S->infer(Cand.BPCs, Cand.PCs, Cand.Mapping.LHS, RHS, IC)) {
+            S->infer(Cand.BPCs, Cand.PCs, Cand.Mapping.LHS, RHSs, IC)) {
       llvm::errs() << "Unable to query solver: " << EC.message() << '\n';
       return false;
     }
-    if (RHS) {
-      Cand.Mapping.RHS = RHS;
+    if (!RHSs.empty()) {
+      Cand.Mapping.RHS = RHSs.front();
       if (Cand.Mapping.RHS->K != Inst::Const) {
         llvm::errs() << "found replacement:\n";
         Cand.printFunction(llvm::errs());

--- a/tools/souper-check.cpp
+++ b/tools/souper-check.cpp
@@ -83,12 +83,14 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
         OldCost = cost(Rep.Mapping.RHS);
         Rep.Mapping.RHS = 0;
       }
+      std::vector<Inst *> RHSs;
       if (std::error_code EC = S->infer(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
-                                        Rep.Mapping.RHS, IC)) {
+                                        RHSs, IC)) {
         llvm::errs() << EC.message() << '\n';
         Ret = 1;
         ++Error;
       }
+      Rep.Mapping.RHS = RHSs.empty() ? 0 : RHSs.front();
       if (Rep.Mapping.RHS) {
         ++Success;
         if (ReInferRHS) {


### PR DESCRIPTION
This patch changes the type of the RHS argument of ExhaustiveSynthesis::synthesize() and Solver::infer() from a Inst pointer to a vector of Inst pointers.

Exhaustive Synthesis now takes a constant "MaxRHS". This constant is set to 1 for performance. Exhaustive Synthesis now generates at most MaxRHS number of RHSs. The original Souper test suite on my machine runs 282.54s while with MaxRHS set to 3, the test suite runs 454.83s.

Call sites of infer() function takes the result vector of RHS and extract the first RHS, this preserves the behaviors of these call sites.