### PR TITLE
Remove unused assembler step in tests

### DIFF
--- a/test/Extractor/abs.ll
+++ b/test/Extractor/abs.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper %solver -S -o - %s | %FileCheck %s
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/Extractor/blockpc1.ll
+++ b/test/Extractor/blockpc1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 ; Function Attrs: nounwind uwtable

--- a/test/Extractor/blockpc2.ll
+++ b/test/Extractor/blockpc2.ll
@@ -1,7 +1,6 @@
 
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define zeroext i1 @c_ispunct(i32 %a, i32 %b, i32 %c) {

--- a/test/Extractor/blockpc3.ll
+++ b/test/Extractor/blockpc3.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 ; RUN: %FileCheck %s < %t
 

--- a/test/Extractor/blockpc4.ll
+++ b/test/Extractor/blockpc4.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 ; RUN: %FileCheck %s < %t
 

--- a/test/Extractor/illegal-sext.ll
+++ b/test/Extractor/illegal-sext.ll
@@ -1,5 +1,4 @@
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %t | %parser-test -LHS
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/Extractor/irreducible-cg.ll
+++ b/test/Extractor/irreducible-cg.ll
@@ -1,7 +1,6 @@
 
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-harvest-demanded-bits=false %t
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/Extractor/pc1.ll
+++ b/test/Extractor/pc1.ll
@@ -1,7 +1,6 @@
 
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 ; Function Attrs: nounwind uwtable

--- a/test/Extractor/pc2.ll
+++ b/test/Extractor/pc2.ll
@@ -1,7 +1,6 @@
 
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 ; Function Attrs: nounwind

--- a/test/Extractor/phi-1.ll
+++ b/test/Extractor/phi-1.ll
@@ -1,7 +1,6 @@
 
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/Extractor/switch-1.ll
+++ b/test/Extractor/switch-1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define zeroext i1 @foo(i32 %a, i32 %b) {

--- a/test/Extractor/vector-gep.ll
+++ b/test/Extractor/vector-gep.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -souper-harvest-dataflow-facts=false -check %t
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/Pass/alive0.ll
+++ b/test/Pass/alive0.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=and,or,ne,const,xor,add,sub,ashr -S -o - %s | %FileCheck %s
 
 define i32 @alive0_0(i32, i32) local_unnamed_addr #0 {

--- a/test/Pass/const-synthesis-fail.ll
+++ b/test/Pass/const-synthesis-fail.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=and,or,ne,xor,const,add,sub,ashr -S -o - %s | %FileCheck %s
 ;XFAIL: *
 

--- a/test/Pass/external-uses.ll
+++ b/test/Pass/external-uses.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=and,const,or,add,xor -S -o - %s | %FileCheck %s
 
 

--- a/test/Pass/must-ignore-cost.ll
+++ b/test/Pass/must-ignore-cost.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-ignore-cost -souper-synthesis-comps=and,or,ne,xor,const,add,sub,ashr -S -o - %s | %FileCheck %s
 
 define i1 @alive0_f2(i16, i16) local_unnamed_addr #0 {

--- a/test/Pass/nop1.ll
+++ b/test/Pass/nop1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper %solver -souper-infer-nop -souper-stress-nop -S -stats -o - %s 2>&1 | %FileCheck %s
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/Pass/nop2.ll
+++ b/test/Pass/nop2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper %solver -souper-infer-nop -souper-stress-nop -S -stats -o - %s 2>&1 | %FileCheck %s
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/Pass/nop3.ll
+++ b/test/Pass/nop3.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper %solver -souper-infer-nop -S -o - %s | %FileCheck %s
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/Pass/nop4.ll
+++ b/test/Pass/nop4.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper %solver -souper-infer-nop -S -o - %s | %FileCheck %s
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/Pass/replace-replacement.ll
+++ b/test/Pass/replace-replacement.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper %solver -souper-infer-nop -souper-stress-nop -S -stats -o - %s 2>&1 | %FileCheck %s
 
 ; CHECK: store i32 %cond.i

--- a/test/Pass/syn-2-inst-blsr.ll
+++ b/test/Pass/syn-2-inst-blsr.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=and,const,or,add,xor -S -o - %s | %FileCheck %s
 
 define i32 @ia32_Blsr_unsupported(i32) local_unnamed_addr #0 {

--- a/test/Pass/syn-icmp-variants.ll
+++ b/test/Pass/syn-icmp-variants.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-exhaustive-synthesis -S -o - %s | %FileCheck %s
 
 define i1 @syn_eq(i32 %x, i32 %y) #0 {

--- a/test/Pass/syn-inst-add-ext-use.ll
+++ b/test/Pass/syn-inst-add-ext-use.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper %solver -souper-infer-inst -souper-synthesis-comps=add,const -S -o - %s | %FileCheck %s
 
 ; Investigation and improvement are needed. Current instruction synthesis can

--- a/test/Pass/syn-inst-add.ll
+++ b/test/Pass/syn-inst-add.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=add,const -S -o - %s | %FileCheck %s
 
 

--- a/test/Pass/syn-inst-and.ll
+++ b/test/Pass/syn-inst-and.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=and,const -S -o - %s | %FileCheck %s
 
 

--- a/test/Pass/syn-inst-ashr.ll
+++ b/test/Pass/syn-inst-ashr.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=ashr,const -S -o - %s | %FileCheck %s
 
 

--- a/test/Pass/syn-inst-bswap.ll
+++ b/test/Pass/syn-inst-bswap.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=bswap -S -o - %s | %FileCheck %s
 
 define i64 @foo(i64 %x) {

--- a/test/Pass/syn-inst-ctlz.ll
+++ b/test/Pass/syn-inst-ctlz.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=ctlz -S -o - %s | %FileCheck %s
 
 define i8 @func(i8 %v) local_unnamed_addr #0 {

--- a/test/Pass/syn-inst-ctpop.ll
+++ b/test/Pass/syn-inst-ctpop.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-ignore-cost -souper-synthesis-comps=ctpop -S -o - %s | %FileCheck %s
 
 ; Translated from test/Infer/popcount6-syn.opt

--- a/test/Pass/syn-inst-cttz.ll
+++ b/test/Pass/syn-inst-cttz.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=cttz -S -o - %s | %FileCheck %s
 
 define i32 @func(i32 %v) local_unnamed_addr #0 {

--- a/test/Pass/syn-inst-lshr.ll
+++ b/test/Pass/syn-inst-lshr.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=lshr,const -S -o - %s | %FileCheck %s
 
 

--- a/test/Pass/syn-inst-mul.ll
+++ b/test/Pass/syn-inst-mul.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=mul,const -S -o - %s | %FileCheck %s
 
 

--- a/test/Pass/syn-inst-or.ll
+++ b/test/Pass/syn-inst-or.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=or,const -S -o - %s | %FileCheck %s
 
 

--- a/test/Pass/syn-inst-select.ll
+++ b/test/Pass/syn-inst-select.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-iN=false -souper-infer-inst -souper-synthesis-comps=select,const,add -S -o - %s | %FileCheck %s
 
 

--- a/test/Pass/syn-inst-sext.ll
+++ b/test/Pass/syn-inst-sext.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -S -o - %s | %FileCheck %s
 
 define i8 @foo(i1 %x) {

--- a/test/Pass/syn-inst-shl.ll
+++ b/test/Pass/syn-inst-shl.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=shl,const -S -o - %s | %FileCheck %s
 
 

--- a/test/Pass/syn-inst-sub.ll
+++ b/test/Pass/syn-inst-sub.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=sub,const -S -o - %s | %FileCheck %s
 
 

--- a/test/Pass/syn-inst-trunc.ll
+++ b/test/Pass/syn-inst-trunc.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -S -o - %s | %FileCheck %s
 
 ; Translated from test/Infer/odd.opt

--- a/test/Pass/syn-inst-xor.ll
+++ b/test/Pass/syn-inst-xor.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=xor,const -S -o - %s | %FileCheck %s
 
 

--- a/test/Pass/syn-inst-zext.ll
+++ b/test/Pass/syn-inst-zext.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -S -o - %s | %FileCheck %s
 
 define i8 @foo(i1 %x) {

--- a/test/Solver/add-nsw-no-opt1.ll
+++ b/test/Solver/add-nsw-no-opt1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i32 @foo(i32 %x) {

--- a/test/Solver/add-nsw-no-opt2.ll
+++ b/test/Solver/add-nsw-no-opt2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i32 @foo(i32 %x) {

--- a/test/Solver/add-nsw.ll
+++ b/test/Solver/add-nsw.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i32 @foo(i32 %x) {

--- a/test/Solver/add-nuw-no-opt1.ll
+++ b/test/Solver/add-nuw-no-opt1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i32 @foo(i32 %x) #0 {

--- a/test/Solver/add-nuw-no-opt2.ll
+++ b/test/Solver/add-nuw-no-opt2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i32 @foo(i32 %x) #0 {

--- a/test/Solver/add-nuw.ll
+++ b/test/Solver/add-nuw.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i32 @foo(i32 %x) #0 {

--- a/test/Solver/alive-bug.ll
+++ b/test/Solver/alive-bug.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i32 @mul(i32 %a, i32 %b) #0 {

--- a/test/Solver/ashr-exact-no-opt.ll
+++ b/test/Solver/ashr-exact-no-opt.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define void @fn1(i32 %x, i32 %y) #0 {

--- a/test/Solver/ashr-exact.ll
+++ b/test/Solver/ashr-exact.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define void @fn1(i32 %x, i32 %y) #0 {

--- a/test/Solver/bachet1.ll
+++ b/test/Solver/bachet1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 ; x^2 + 2 = y^3 has a unique positive solution

--- a/test/Solver/bachet2.ll
+++ b/test/Solver/bachet2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 ; x^2 - 45 = y^3 has no positive solution

--- a/test/Solver/blockpc_ifelse1.ll
+++ b/test/Solver/blockpc_ifelse1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -souper-exploit-blockpcs -check -souper-infer-iN=false %t
 
 define i32 @foo(i32 %x) {

--- a/test/Solver/blockpc_ifelse2.ll
+++ b/test/Solver/blockpc_ifelse2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -souper-exploit-blockpcs -check -souper-infer-iN=false %t
 
 define i32 @foo(i32 %x) {

--- a/test/Solver/blockpc_switch.ll
+++ b/test/Solver/blockpc_switch.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -souper-exploit-blockpcs -souper-infer-iN=false -check %t
 
 define i32 @foo(i32 %a) #0 {

--- a/test/Solver/bswap.ll
+++ b/test/Solver/bswap.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 ; Function Attrs: nounwind readnone

--- a/test/Solver/bswap2.ll
+++ b/test/Solver/bswap2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 ; Function Attrs: nounwind readnone

--- a/test/Solver/bswap3.ll
+++ b/test/Solver/bswap3.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 ; Function Attrs: nounwind readnone

--- a/test/Solver/bswap4.ll
+++ b/test/Solver/bswap4.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 ; Function Attrs: nounwind readnone

--- a/test/Solver/ctlz.ll
+++ b/test/Solver/ctlz.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 declare i64 @llvm.ctlz.i64(i64) nounwind readnone

--- a/test/Solver/ctlz2.ll
+++ b/test/Solver/ctlz2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 declare i32 @llvm.ctlz.i32(i32) nounwind readnone

--- a/test/Solver/ctpop.ll
+++ b/test/Solver/ctpop.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 ; This test case input in hex is 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 

--- a/test/Solver/ctpop2.ll
+++ b/test/Solver/ctpop2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 declare i32 @llvm.ctpop.i32(i32) nounwind readnone

--- a/test/Solver/cttz.ll
+++ b/test/Solver/cttz.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 declare i64 @llvm.cttz.i64(i64) nounwind readnone

--- a/test/Solver/cttz2.ll
+++ b/test/Solver/cttz2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 declare i32 @llvm.cttz.i32(i32) nounwind readnone

--- a/test/Solver/div-by-zero1.ll
+++ b/test/Solver/div-by-zero1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define void @fn1() {

--- a/test/Solver/div-by-zero2.ll
+++ b/test/Solver/div-by-zero2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define void @fn1() {

--- a/test/Solver/div-by-zero3.ll
+++ b/test/Solver/div-by-zero3.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define void @fn1() {

--- a/test/Solver/eggs.ll
+++ b/test/Solver/eggs.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 ; A woman was carrying a large basket of eggs when a passer-by bumped her and

--- a/test/Solver/extract.ll
+++ b/test/Solver/extract.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/Solver/fermat.ll
+++ b/test/Solver/fermat.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define void @fermat(i20 %a, i20 %b, i20 %c) #0 {

--- a/test/Solver/mul-nsw1-no-opt1.ll
+++ b/test/Solver/mul-nsw1-no-opt1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i32 @mul(i32 %a) #0 {

--- a/test/Solver/mul-nsw1.ll
+++ b/test/Solver/mul-nsw1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i32 @mul(i32 %a) #0 {

--- a/test/Solver/mul-nsw2.ll
+++ b/test/Solver/mul-nsw2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define void @mul(i12 %a) #0 {

--- a/test/Solver/mul-nuw1-no-opt1.ll
+++ b/test/Solver/mul-nuw1-no-opt1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i32 @foo(i32 %x) #0 {

--- a/test/Solver/mul-nuw1-no-opt2.ll
+++ b/test/Solver/mul-nuw1-no-opt2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i32 @foo(i32 %x) #0 {

--- a/test/Solver/mul-nuw1.ll
+++ b/test/Solver/mul-nuw1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i32 @foo(i32 %x) #0 {

--- a/test/Solver/mul-nuw2.ll
+++ b/test/Solver/mul-nuw2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define void @foo(i32 %x) #0 {

--- a/test/Solver/no-blockpc_ifelse1.ll
+++ b/test/Solver/no-blockpc_ifelse1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -souper-exploit-blockpcs=false -check -souper-infer-iN=false %t
 
 define i32 @foo(i32 %x) {

--- a/test/Solver/overflow1.ll
+++ b/test/Solver/overflow1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 ; Function Attrs: nounwind readnone

--- a/test/Solver/overflow2.ll
+++ b/test/Solver/overflow2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 ; Function Attrs: nounwind readnone

--- a/test/Solver/overflow3.ll
+++ b/test/Solver/overflow3.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 ; ModuleID = 'overflow3.ll'

--- a/test/Solver/overflow4.ll
+++ b/test/Solver/overflow4.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 ; ModuleID = 'overflow4.ll'

--- a/test/Solver/overflow5.ll
+++ b/test/Solver/overflow5.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 ; Function Attrs: nounwind readnone

--- a/test/Solver/overflow6.ll
+++ b/test/Solver/overflow6.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 ; Function Attrs: nounwind readnone

--- a/test/Solver/overflow7.ll
+++ b/test/Solver/overflow7.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 ; Function Attrs: nounwind readnone

--- a/test/Solver/overflow8.ll
+++ b/test/Solver/overflow8.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 ; Function Attrs: nounwind readnone

--- a/test/Solver/pc.ll
+++ b/test/Solver/pc.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 @a = common global i64 0, align 4

--- a/test/Solver/phi-block-predicates.ll
+++ b/test/Solver/phi-block-predicates.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i1 @foo(i32 %a) {

--- a/test/Solver/phi-block-predicates2.ll
+++ b/test/Solver/phi-block-predicates2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i1 @foo(i32 %a) {

--- a/test/Solver/phi-block-predicates3.ll
+++ b/test/Solver/phi-block-predicates3.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i1 @foo(i32 %a) {

--- a/test/Solver/phi-ub-predicates.ll
+++ b/test/Solver/phi-ub-predicates.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i1 @foo(i32 %a) {

--- a/test/Solver/phi-ub-predicates2a.ll
+++ b/test/Solver/phi-ub-predicates2a.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i1 @foo(i32 %a) {

--- a/test/Solver/phi-ub-predicates2b.ll
+++ b/test/Solver/phi-ub-predicates2b.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i1 @foo(i32 %a) {

--- a/test/Solver/phi-ub-predicates3a.ll
+++ b/test/Solver/phi-ub-predicates3a.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i1 @foo(i32 %a, i32 %b, i32 %c) {

--- a/test/Solver/phi-ub-predicates3b.ll
+++ b/test/Solver/phi-ub-predicates3b.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i1 @foo(i32 %a, i32 %b, i32 %c) {

--- a/test/Solver/phi-ub-predicates4a.ll
+++ b/test/Solver/phi-ub-predicates4a.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i1 @foo(i32 %a, i32 %b) {

--- a/test/Solver/phi-ub-predicates4b.ll
+++ b/test/Solver/phi-ub-predicates4b.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i1 @foo(i32 %a, i32 %b) {

--- a/test/Solver/phi-ub-predicates5.ll
+++ b/test/Solver/phi-ub-predicates5.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i1 @foo(i32 %a) {

--- a/test/Solver/power2.ll
+++ b/test/Solver/power2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 declare i64 @llvm.ctpop.i64(i64) nounwind readnone

--- a/test/Solver/sdiv-cornercase.ll
+++ b/test/Solver/sdiv-cornercase.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define void @foo(i32 %x) {

--- a/test/Solver/select-ub-predicates.ll
+++ b/test/Solver/select-ub-predicates.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i32 @foo(i32 %x0) {

--- a/test/Solver/select-ub-predicates2a.ll
+++ b/test/Solver/select-ub-predicates2a.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i1 @foo(i32 %a, i1 %b) {

--- a/test/Solver/select-ub-predicates2b.ll
+++ b/test/Solver/select-ub-predicates2b.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i1 @foo(i32 %a, i1 %b) {

--- a/test/Solver/shl-nuw-no-opt1.ll
+++ b/test/Solver/shl-nuw-no-opt1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i32 @foo(i32 %x, i32 %y) #0 {

--- a/test/Solver/shl-nuw.ll
+++ b/test/Solver/shl-nuw.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i32 @foo(i32 %x, i32 %y) #0 {

--- a/test/Solver/srem.ll
+++ b/test/Solver/srem.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i32 @foo(i32 %x) {

--- a/test/Solver/sub-nsw.ll
+++ b/test/Solver/sub-nsw.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define void @foo(i64 %a) #0 {

--- a/test/Solver/sub-nuw-no-opt1.ll
+++ b/test/Solver/sub-nuw-no-opt1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i32 @foo(i32 %a, i32 %b) #0 {

--- a/test/Solver/sub-nuw-no-opt2.ll
+++ b/test/Solver/sub-nuw-no-opt2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i32 @foo(i32 %a, i32 %b) #0 {

--- a/test/Solver/sub-nuw.ll
+++ b/test/Solver/sub-nuw.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i256 @foo(i256 %a, i256 %b) #0 {

--- a/test/Solver/udiv-exact-no-opt.ll
+++ b/test/Solver/udiv-exact-no-opt.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define i32 @fn1(i32 %a) #0 {

--- a/test/Solver/udiv-exact.ll
+++ b/test/Solver/udiv-exact.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 define i16 @fn1(i16 %a) #0 {

--- a/test/Solver/udiv.ll
+++ b/test/Solver/udiv.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 define void @foo(i64 %x, i64 %y) {

--- a/test/Solver/zeros.ll
+++ b/test/Solver/zeros.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 declare i32 @llvm.ctlz.i32(i32) nounwind readnone

--- a/test/Tool/expected.ll
+++ b/test/Tool/expected.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t 2> %t2 || true
 ; RUN: %FileCheck %s < %t2
 

--- a/test/Tool/intrinsic.ll
+++ b/test/Tool/intrinsic.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
 declare i64 @llvm.bswap.i64(i64) #0

--- a/test/Tool/unexpected1.ll
+++ b/test/Tool/unexpected1.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t 2> %t2 || true
 ; RUN: %FileCheck %s < %t2
 

--- a/test/Tool/unexpected2.ll
+++ b/test/Tool/unexpected2.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: solver
 
-; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t 2> %t2 || true
 ; RUN: %FileCheck %s < %t2
 


### PR DESCRIPTION
Removes the following runline from 119  tests.
; RUN: %llvm-as -o %t %s
%t was never used, opt was being invoked with %s
'make check' with 16 cores takes about 5 seconds less to complete.