### PR TITLE
currently, souper attempts to synthesize a better computation for all

### DIFF
--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -767,12 +767,14 @@ void ExtractExprCandidates(Function &F, const LoopInfo *LI, DemandedBits *DB,
   for (auto &BB : F) {
     std::unique_ptr<BlockCandidateSet> BCS(new BlockCandidateSet);
     for (auto &I : BB) {
-      if (I.getType()->isIntegerTy()) {
-        Inst *In = EB.get(&I);
-        EB.markExternalUses(In);
-        BCS->Replacements.emplace_back(&I, InstMapping(In, 0));
-        assert(EB.get(&I)->hasOrigin(&I));
-      }
+      if (!I.getType()->isIntegerTy())
+        continue;
+      if (I.hasNUses(0))
+        continue;
+      Inst *In = EB.get(&I);
+      EB.markExternalUses(In);
+      BCS->Replacements.emplace_back(&I, InstMapping(In, 0));
+      assert(EB.get(&I)->hasOrigin(&I));
     }
     if (!BCS->Replacements.empty()) {
       std::unordered_set<Block *> VisitedBlocks;

--- a/test/Extractor/switch-1.ll
+++ b/test/Extractor/switch-1.ll
@@ -17,11 +17,11 @@ default:                                    ; preds = %entry
 
 bb1:                                        ; preds = %default
   %cmp2 = icmp ne i32 %a, 1, !expected !1
-  br i1 %cmp1, label %bb2, label %bb5
+  br i1 %cmp2, label %bb2, label %bb5
 
 bb2:                                        ; preds = %bb1
   %cmp3 = icmp ne i32 %a, 2, !expected !1
-  br i1 %cmp1, label %bb3, label %bb5
+  br i1 %cmp3, label %bb3, label %bb5
 
 bb3:                                        ; preds = %bb2
   br label %bb5

--- a/test/Infer/eggs2.ll
+++ b/test/Infer/eggs2.ll
@@ -39,7 +39,7 @@ cont6:
   br i1 %cmp7, label %cont7, label %out
 cont7:
   %res = add i10 %x, 0
-  ret i10 %x
+  ret i10 %res
 out:
   ret i10 0
 }

--- a/test/Infer/eggs3-syn.ll
+++ b/test/Infer/eggs3-syn.ll
@@ -39,7 +39,7 @@ cont6:
   br i1 %cmp7, label %cont7, label %out
 cont7:
   %res = add i10 %x, 0
-  ret i10 %x
+  ret i10 %res
 out:
   ret i10 0
 }

--- a/test/Pass/dump-all-replacements.ll
+++ b/test/Pass/dump-all-replacements.ll
@@ -7,8 +7,8 @@
 
 ; CHECK: Listing all replacements for foo
 ; CHECK: 0:i1 = eq 1:i32, 1:i32
-define void @foo() {
+define i1 @foo() {
 entry:
   %t = icmp eq i32 1, 1
-  ret void
+  ret i1 %t
 }

--- a/test/Solver/ashr-exact.ll
+++ b/test/Solver/ashr-exact.ll
@@ -3,13 +3,13 @@
 ; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
-define void @fn1(i32 %x, i32 %y) #0 {
+define i1 @fn1(i32 %x, i32 %y) #0 {
 entry:
   %shr = ashr exact i32 %x, %y
   %a = icmp ne i32 %x, 0
   %b = icmp ne i32 %shr, 0
   %c = xor i1 %a, %b, !expected !0
-  ret void
+  ret i1 %c
 }
 
 !0 = !{i1 0}

--- a/test/Solver/bachet1.ll
+++ b/test/Solver/bachet1.ll
@@ -3,6 +3,8 @@
 ; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
+declare void @sink(i1) nounwind readnone
+
 ; x^2 + 2 = y^3 has a unique positive solution
 
 define void @bachet1(i32 %x, i32 %y) #0 {
@@ -15,7 +17,9 @@ entry:
   br i1 %cmp1, label %cont, label %out
 cont:
   %check1 = icmp eq i32 %x, 5, !expected !1
+  call void @sink(i1 %check1)
   %check2 = icmp eq i32 %y, 3, !expected !1
+  call void @sink(i1 %check2)
   ret void
 out:
   ret void

--- a/test/Solver/bachet2.ll
+++ b/test/Solver/bachet2.ll
@@ -5,14 +5,14 @@
 
 ; x^2 - 45 = y^3 has no positive solution
 
-define void @bachet2(i32 %x, i32 %y) #0 {
+define i1 @bachet2(i32 %x, i32 %y) #0 {
 entry:
   %xsqr = mul nuw i32 %x, %x
   %ysqr = mul nuw i32 %y, %y
   %ycub = mul nuw i32 %y, %ysqr
   %xsqrm45 = sub nuw i32 %xsqr, 45
   %cmp1 = icmp eq i32 %xsqrm45, %ycub, !expected !0
-  ret void
+  ret i1 %cmp1
 }
 
 !0 = !{i1 0}

--- a/test/Solver/bswap.ll
+++ b/test/Solver/bswap.ll
@@ -6,14 +6,14 @@
 ; Function Attrs: nounwind readnone
 declare i16 @llvm.bswap.i16(i16) #0
 
-define i16 @foo(i16 %x) {
+define i1 @foo(i16 %x) {
 entry:
   %0 = shl i16 %x, 8
   %1 = lshr i16 %x, 8
   %2 = or i16 %0, %1
   %swap1 = call i16 @llvm.bswap.i16(i16 %x)
   %cmp1 = icmp eq i16 %swap1, %2, !expected !1
-  ret i16 %swap1
+  ret i1 %cmp1
 }
 
 !1 = !{i1 1}

--- a/test/Solver/bswap2.ll
+++ b/test/Solver/bswap2.ll
@@ -7,13 +7,13 @@
 declare i32 @llvm.bswap.i32(i32) #0
 declare i32 @llvm.ctpop.i32(i32) #1
 
-define i32 @foo(i32 %x) {
+define i1 @foo(i32 %x) {
 entry:
   %count1 = call i32 @llvm.ctpop.i32(i32 %x)
   %swap = call i32 @llvm.bswap.i32(i32 %x)
   %count2 = call i32 @llvm.ctpop.i32(i32 %swap)
   %cmp = icmp eq i32 %count1, %count2, !expected !1
-  ret i32 %swap
+  ret i1 %cmp
 }
 
 !1 = !{i1 1}

--- a/test/Solver/bswap3.ll
+++ b/test/Solver/bswap3.ll
@@ -6,11 +6,11 @@
 ; Function Attrs: nounwind readnone
 declare i32 @llvm.bswap.i32(i32) #0
 
-define i32 @foo(i32 %x) {
+define i1 @foo(i32 %x) {
 entry:
   %swap = call i32 @llvm.bswap.i32(i32 2882343476) ;input is 0xABCD1234
   %cmp = icmp eq i32 %swap, 873647531, !expected !1 ;swapped result is 0x3412CDAB
-  ret i32 %swap
+  ret i1 %cmp
 }
 
 !1 = !{i1 1}

--- a/test/Solver/bswap4.ll
+++ b/test/Solver/bswap4.ll
@@ -6,11 +6,11 @@
 ; Function Attrs: nounwind readnone
 declare i64 @llvm.bswap.i64(i64) #0
 
-define i64 @foo(i64 %x) {
+define i1 @foo(i64 %x) {
 entry:
   %swap = call i64 @llvm.bswap.i64(i64 12379570966709668117) ;input is 0xABCD123456780915
   %cmp = icmp eq i64 %swap, 1515875061223050667, !expected !1 ;swapped result is 0x150978563412CDAB
-  ret i64 %swap
+  ret i1 %cmp
 }
 
 !1 = !{i1 1}

--- a/test/Solver/ctlz.ll
+++ b/test/Solver/ctlz.ll
@@ -5,11 +5,11 @@
 
 declare i64 @llvm.ctlz.i64(i64) nounwind readnone
 
-define i64 @foo(i64 %x) {
+define i1 @foo(i64 %x) {
 entry:
   %count = call i64 @llvm.ctlz.i64(i64 281479271743489) ;input is 0x0001000100010001
   %cmp = icmp eq i64 %count, 15, !expected !1
-  ret i64 %count
+  ret i1 %cmp
 }
 
 !1 = !{i1 1}

--- a/test/Solver/ctpop.ll
+++ b/test/Solver/ctpop.ll
@@ -6,11 +6,11 @@
 
 declare i256 @llvm.ctpop.i256(i256) nounwind readnone
 
-define i256 @foo(i256 %x) {
+define i1 @foo(i256 %x) {
 entry:
   %pop = call i256 @llvm.ctpop.i256(i256 77194726158210796949047323339125271902179989777093709359638389338608753093290)
   %cmp = icmp eq i256 %pop, 128, !expected !1
-  ret i256 %pop
+  ret i1 %cmp
 }
 
 !1 = !{i1 1}

--- a/test/Solver/ctpop2.ll
+++ b/test/Solver/ctpop2.ll
@@ -4,6 +4,7 @@
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
 declare i32 @llvm.ctpop.i32(i32) nounwind readnone
+declare void @sink(i1) nounwind readnone
 
 define void @foo(i32 %x, i32 %y) {
 entry:
@@ -12,11 +13,12 @@ entry:
   %pop2 = call i32 @llvm.ctpop.i32(i32 %notx)
   %sum = add i32 %pop1, %pop2
   %cmp2 = icmp eq i32 %sum, 32, !expected !1
+  call void @sink(i1 %cmp2)
   %shift = lshr exact i32 %x, %y
   %pop3 = call i32 @llvm.ctpop.i32(i32 %shift)
   %cmp3 = icmp eq i32 %pop1, %pop3, !expected !1
+  call void @sink(i1 %cmp3)
   ret void
-
 }
 
 !1 = !{i1 1}

--- a/test/Solver/cttz2.ll
+++ b/test/Solver/cttz2.ll
@@ -5,7 +5,7 @@
 
 declare i32 @llvm.cttz.i32(i32) nounwind readnone
 
-define void @foo(i32 %x, i32 %y) {
+define i1 @foo(i32 %x, i32 %y) {
 entry:
   %zero = icmp eq i32 %x, 0
   %count1 = call i32 @llvm.cttz.i32(i32 %x)
@@ -14,8 +14,7 @@ entry:
   %count1plusy = add i32 %count1, %y
   %eq = icmp eq i32 %count1plusy, %count2
   %cmp = or i1 %eq, %zero, !expected !1
-
-  ret void
+  ret i1 %cmp
 }
 
 !1 = !{i1 1}

--- a/test/Solver/eggs.ll
+++ b/test/Solver/eggs.ll
@@ -3,6 +3,8 @@
 ; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check -souper-infer-iN=false %t
 
+declare void @sink(i1) nounwind readnone
+
 ; A woman was carrying a large basket of eggs when a passer-by bumped her and
 ; she dropped the basket and all the eggs broke. The passer-by asked how many
 ; eggs there had been. The woman replied: "I don't remember exactly, but I do
@@ -38,8 +40,10 @@ cont5:
 cont6:
   %check1 = icmp eq i10 %x, 301
   %check2 = icmp eq i10 %x, 721
-  %check = or i1 %check1, %check2, !expected !1 
+  %check = or i1 %check1, %check2, !expected !1
   %check3 = icmp eq i10 %x, 999, !expected !0
+  call void @sink(i1 %check)
+  call void @sink(i1 %check3)
   ret i10 %x
 out:
   ret i10 0

--- a/test/Solver/fermat.ll
+++ b/test/Solver/fermat.ll
@@ -3,7 +3,7 @@
 ; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
-define void @fermat(i20 %a, i20 %b, i20 %c) #0 {
+define i1 @fermat(i20 %a, i20 %b, i20 %c) #0 {
 entry:
   %ainc = add nuw i20 %a, 1
   %asqr = mul nuw i20 %ainc, %ainc
@@ -16,7 +16,7 @@ entry:
   %ccub = mul nuw i20 %cinc, %csqr
   %abcub = add nuw i20 %acub, %bcub
   %cmp = icmp eq i20 %abcub, %ccub, !expected !0
-  ret void
+  ret i1 %cmp
 }
 
 !0 = !{i1 0}

--- a/test/Solver/mul-nsw2.ll
+++ b/test/Solver/mul-nsw2.ll
@@ -3,12 +3,16 @@
 ; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
+declare void @sink(i1) nounwind readnone
+
 define void @mul(i12 %a) #0 {
 entry:
   %nega = sub i12 0, %a
   %mul = mul nsw i12 %a, %nega
   %cmp1 = icmp sgt i12 %mul, %a, !expected !0
   %cmp2 = icmp sgt i12 %mul, %nega, !expected !0
+  call void @sink(i1 %cmp1)
+  call void @sink(i1 %cmp2)
   ret void
 }
 

--- a/test/Solver/mul-nuw2.ll
+++ b/test/Solver/mul-nuw2.ll
@@ -3,13 +3,13 @@
 ; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
-define void @foo(i32 %x) #0 {
+define i1 @foo(i32 %x) #0 {
 entry:
   %mul = mul nuw i32 %x, 4294967295
   %cmp1 = icmp eq i32 %mul, 0
   %cmp2 = icmp eq i32 %mul, 4294967295
   %cmp = or i1 %cmp1, %cmp2, !expected !1
-  ret void
+  ret i1 %cmp
 }
 
 !1 = !{i1 1}

--- a/test/Solver/overflow5.ll
+++ b/test/Solver/overflow5.ll
@@ -13,7 +13,8 @@ entry:
   %bit = extractvalue { i32, i1 } %add, 1
   %cmp = icmp ugt i32 %sum, 0
   %res = or i1 %bit, %cmp, !expected !1
-  %conv = zext i1 %cmp to i32
+  %conv = zext i1 %res to i32, !expected !132
   ret i32 %conv
 }
 !1 = !{ i1 1 }
+!132 = !{ i32 1 }

--- a/test/Solver/power2.ll
+++ b/test/Solver/power2.ll
@@ -6,6 +6,7 @@
 declare i64 @llvm.ctpop.i64(i64) nounwind readnone
 declare i64 @llvm.ctlz.i64(i64) nounwind readnone
 declare i64 @llvm.cttz.i64(i64) nounwind readnone
+declare void @sink(i1) nounwind readnone
 
 define void @foo(i64 %x) {
 entry:
@@ -23,10 +24,14 @@ entry:
 ispower2:
   %cmp1 = icmp eq i64 %pop, 1, !expected !1
   %cmp2 = icmp eq i64 %add, 63, !expected !1
+  call void @sink(i1 %cmp1)
+  call void @sink(i1 %cmp2)
   ret void
 notpower2:
   %cmp3 = icmp eq i64 %pop, 1, !expected !0
   %cmp4 = icmp eq i64 %add, 63, !expected !0
+  call void @sink(i1 %cmp3)
+  call void @sink(i1 %cmp4)
   ret void
 }
 

--- a/test/Solver/sdiv-cornercase.ll
+++ b/test/Solver/sdiv-cornercase.ll
@@ -3,13 +3,13 @@
 ; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
-define void @foo(i32 %x) {
+define i1 @foo(i32 %x) {
 entry:
   %div = sdiv i32 %x, -1
   %a = icmp ne i32 %x, -2147483648
   %b = icmp ne i32 %div, %div, !expected !0
   %c = or i1 %a, %b, !expected !1
-  ret void
+  ret i1 %c
 }
 
 !0 = !{i1 0}

--- a/test/Solver/sub-nsw.ll
+++ b/test/Solver/sub-nsw.ll
@@ -3,13 +3,13 @@
 ; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
-define void @foo(i64 %a) #0 {
+define i1 @foo(i64 %a) #0 {
 entry:
   %nega = sub nsw i64 0, %a
   %cmp1 = icmp sge i64 %a, 0
   %cmp2 = icmp sge i64 %nega, 0
   %cmp = or i1 %cmp1, %cmp2, !expected !1
-  ret void
+  ret i1 %cmp
 }
 
 !1 = !{i1 1}

--- a/test/Solver/udiv.ll
+++ b/test/Solver/udiv.ll
@@ -3,13 +3,13 @@
 ; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
-define void @foo(i64 %x, i64 %y) {
+define i1 @foo(i64 %x, i64 %y) {
 entry:
   %div = udiv i64 %x, %y
   %a = icmp ne i64 %y, 0
   %b = icmp ne i64 %div, %div, !expected !0
   %c = or i1 %a, %b, !expected !1
-  ret void
+  ret i1 %c
 }
 
 !0 = !{i1 0}

--- a/test/Solver/zeros.ll
+++ b/test/Solver/zeros.ll
@@ -6,6 +6,7 @@
 declare i32 @llvm.ctlz.i32(i32) nounwind readnone
 declare i32 @llvm.cttz.i32(i32) nounwind readnone
 declare i32 @llvm.ctpop.i32(i32) nounwind readnone
+declare void @sink(i1) nounwind readnone
 
 define void @foo(i32 %x) {
 entry:
@@ -21,6 +22,10 @@ zero:
 
   %allZeros2 = call i32 @llvm.cttz.i32(i32 %x)
   %cmp3 = icmp eq i32 %allZeros2, 32, !expected !1
+
+  call void @sink(i1 %cmp1)
+  call void @sink(i1 %cmp2)
+  call void @sink(i1 %cmp3)
 
   br label %out
 
@@ -43,6 +48,17 @@ nonzero:
   %cmp11 = icmp slt i32 %ltZeros, 32, !expected !1
 
   %cmp12 = icmp slt i32 %zeros, %ltZeros, !expected !0
+
+  call void @sink(i1 %cmp4)
+  call void @sink(i1 %cmp5)
+  call void @sink(i1 %cmp6)
+  call void @sink(i1 %cmp7)
+  call void @sink(i1 %cmp8)
+  call void @sink(i1 %cmp9)
+  call void @sink(i1 %cmp10)
+  call void @sink(i1 %cmp11)
+  call void @sink(i1 %cmp12)
+
   br label %out
 
 out:

--- a/test/Tool/intrinsic.ll
+++ b/test/Tool/intrinsic.ll
@@ -5,12 +5,12 @@
 
 declare i64 @llvm.bswap.i64(i64) #0
 
-define void @foo(i64 %x) {
+define i1 @foo(i64 %x) {
 entry:
   %swap1 = call i64 @llvm.bswap.i64(i64 %x)
   %swap2 = call i64 @llvm.bswap.i64(i64 %swap1)
   %cmp = icmp eq i64 %x, %swap2, !expected !1
-  ret void
+  ret i1 %cmp
 }
 
 !1 = !{i1 1}

--- a/test/Tool/unexpected1.ll
+++ b/test/Tool/unexpected1.ll
@@ -4,7 +4,7 @@
 ; RUN: %souper %solver -check %t 2> %t2 || true
 ; RUN: %FileCheck %s < %t2
 
-define void @foo() {
+define i1 @foo() {
 entry:
   ; CHECK: instruction:
   ; CHECK-NEXT: icmp eq i32 0, 0
@@ -13,5 +13,5 @@ entry:
   ; CHECK-NEXT: %0:i1 = eq 0:i32, 0:i32
   ; CHECK-NEXT: cand %0 1:i1
   %cmp = icmp eq i32 0, 0
-  ret void
+  ret i1 %cmp
 }

--- a/test/Tool/unexpected2.ll
+++ b/test/Tool/unexpected2.ll
@@ -4,7 +4,7 @@
 ; RUN: %souper %solver -check %t 2> %t2 || true
 ; RUN: %FileCheck %s < %t2
 
-define void @foo() {
+define i1 @foo() {
 entry:
   ; CHECK: instruction:
   ; CHECK-NEXT: icmp eq i32 0, 0
@@ -13,7 +13,7 @@ entry:
   ; CHECK-NEXT: %0:i1 = eq 0:i32, 0:i32
   ; CHECK-NEXT: cand %0 1:i1
   %cmp = icmp eq i32 0, 0, !expected !0
-  ret void
+  ret i1 %cmp
 }
 
 !0 = !{i1 0}

--- a/unittests/Extractor/ExtractorTests.cpp
+++ b/unittests/Extractor/ExtractorTests.cpp
@@ -95,13 +95,14 @@ struct ExtractorTest : testing::Test {
 
 TEST_F(ExtractorTest, Simple) {
   ASSERT_TRUE(extractFromIR(R"m(
-define void @f(i32 %p, i32 %q) {
+define i1 @f(i32 %p, i32 %q) {
   %ult = icmp ult i32 %p, %q
 
   %add = add i32 %p, %q
   %ult1 = icmp ult i32 %p, %add
 
-  ret void
+  %and = or i1 %ult, %ult1
+  ret i1 %and
 }
 )m"));
 
@@ -115,10 +116,10 @@ define void @f(i32 %p, i32 %q) {
 
 TEST_F(ExtractorTest, Nsw) {
   ASSERT_TRUE(extractFromIR(R"m(
-define void @f(i32 %p, i32 %q) {
+define i1 @f(i32 %p, i32 %q) {
   %add = add nsw i32 %p, %q
   %ult = icmp ult i32 %p, %add
-  ret void
+  ret i1 %ult
 }
 )m"));
 
@@ -130,7 +131,7 @@ define void @f(i32 %p, i32 %q) {
 
 TEST_F(ExtractorTest, PhiCond) {
   ASSERT_TRUE(extractFromIR(R"m(
-define void @f(i32 %p, i32 %q) {
+define i1 @f(i32 %p, i32 %q) {
 entry:
   br i1 undef, label %t, label %f
 
@@ -145,7 +146,7 @@ f:
 cont:
   %phi = phi i32 [ %paq, %t ], [ %pmq, %f ]
   %ult = icmp ult i32 %p, %phi
-  ret void
+  ret i1 %ult
 }
 )m"));
 
@@ -181,7 +182,7 @@ cand %2 1:i1
 TEST_F(ExtractorTest, PathCondition) {
   // Expected equivalence classes are {p, q, r} and {s}.
   ASSERT_TRUE(extractFromIR(R"m(
-define void @f(i1 %p, i1 %q, i1 %r, i1 %s) {
+define i1 @f(i1 %p, i1 %q, i1 %r, i1 %s) {
 entry:
   %pq = and i1 %p, %q
   br i1 %pq, label %bb1, label %u
@@ -199,7 +200,8 @@ bb3:
 bb4:
   %cmp1 = icmp eq i1 %p, true
   %cmp2 = icmp eq i1 %s, true
-  ret void
+  %or = or i1 %cmp1, %cmp2
+  ret i1 %or
 
 u:
   unreachable


### PR DESCRIPTION
integer-typed registers, even those that have no uses. previously this
was a bit wasteful, but not problematic. however, since turning
demanded bits on by default, souper started synthesizing and replacing
every non-used return value from a function, which is just silly.

this patch causes souper to only extract registers that have at least
one use. the patch is trivial but it broke a lot of tests, which are
all fixed in obvious ways.