### PR TITLE
CMake: mark 'check' target as using terminal.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,8 @@ configure_file(
 
 add_custom_target(check
   COMMAND ${CMAKE_BINARY_DIR}/run_lit
-  DEPENDS extractor_tests inst_tests parser-test parser_tests profileRuntime souper souper-check souperPass souperPassProfileAll)
+  DEPENDS extractor_tests inst_tests parser-test parser_tests profileRuntime souper souper-check souperPass souperPassProfileAll
+  USES_TERMINAL)
 
 find_program(GO_EXECUTABLE NAMES go DOC "go executable")
 if(NOT GO_EXECUTABLE STREQUAL "GO_EXECUTABLE-NOTFOUND")


### PR DESCRIPTION
Else, all the `lit` output is being buffered, and is flushed after
the target finishes 'building'. In particular, that hides the
progress meter.