### PR TITLE
Specify -souper-synthesis-comps= in syn-inst-trunc.ll test

### DIFF
--- a/test/Pass/syn-inst-trunc.ll
+++ b/test/Pass/syn-inst-trunc.ll
@@ -1,7 +1,7 @@
 ; REQUIRES: solver
 
 ; RUN: %llvm-as -o %t %s
-; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -S -o - %s | %FileCheck %s
+; RUN: %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=add,sub,mul,const -S -o - %s | %FileCheck %s
 
 ; Translated from test/Infer/odd.opt
 


### PR DESCRIPTION
While currently that test does not crash (for me at least,
with standard stack size), it does start crashing like in
https://github.com/google/souper/issues/400
with WIP patch for `fsh[lr]` handling.

The rest (or at least some of) of the `syn-inst-*.ll` tests
do specify `-souper-synthesis-comps=` explicitly, so i guess
this one should/can too?

Note that i specify `const`, since `trunc` is implicit,
and can't be specified manually there.