### PR TITLE
Support for LLVM IR funnel shift left/right intrinsic

### DIFF
--- a/include/souper/Infer/InstSynthesis.h
+++ b/include/souper/Infer/InstSynthesis.h
@@ -123,7 +123,9 @@ static const std::vector<Component> CompLibrary = {
   Component{Inst::CtPop, 0, {0}},
   Component{Inst::BSwap, 0, {0}},
   Component{Inst::Cttz, 0, {0}},
-  Component{Inst::Ctlz, 0, {0}}
+  Component{Inst::Ctlz, 0, {0}},
+  Component{Inst::FShl, 0, {0,0,0}},
+  Component{Inst::FShr, 0, {0,0,0}}
 };
 
 class InstSynthesis {

--- a/include/souper/Inst/Inst.h
+++ b/include/souper/Inst/Inst.h
@@ -91,6 +91,8 @@ struct Inst : llvm::FoldingSetNode {
     BSwap,
     Cttz,
     Ctlz,
+    FShl,
+    FShr,
     ExtractValue,
     SAddWithOverflow,
     SAddO,

--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -510,6 +510,14 @@ Inst *ExprBuilder::buildHelper(Value *V) {
           return IC.getInst(Inst::Cttz, L->Width, {L});
         case Intrinsic::ctlz:
           return IC.getInst(Inst::Ctlz, L->Width, {L});
+        case Intrinsic::fshl:
+        case Intrinsic::fshr: {
+          Inst *Low = get(II->getOperand(1));
+          Inst *ShAmt = get(II->getOperand(2));
+          Inst::Kind K =
+              II->getIntrinsicID() == Intrinsic::fshl ? Inst::FShl : Inst::FShr;
+          return IC.getInst(K, L->Width, {/*High*/L, Low, ShAmt});
+        }
         case Intrinsic::sadd_with_overflow: {
           Inst *R = get(II->getOperand(1));
           Inst *Add = IC.getInst(Inst::Add, L->Width, {L, R}, /*Available=*/false);

--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -516,7 +516,7 @@ Inst *ExprBuilder::buildHelper(Value *V) {
           Inst *ShAmt = get(II->getOperand(2));
           Inst::Kind K =
               II->getIntrinsicID() == Intrinsic::fshl ? Inst::FShl : Inst::FShr;
-          return IC.getInst(K, L->Width, {/*High*/L, Low, ShAmt});
+          return IC.getInst(K, L->Width, {/*High=*/L, Low, ShAmt});
         }
         case Intrinsic::sadd_with_overflow: {
           Inst *R = get(II->getOperand(1));

--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -400,6 +400,10 @@ const char *Inst::getKindName(Kind K) {
     return "cttz";
   case Ctlz:
     return "ctlz";
+  case FShl:
+    return "fshl";
+  case FShr:
+    return "fshr";
   case ExtractValue:
     return "extractvalue";
   case SAddWithOverflow:
@@ -476,6 +480,8 @@ Inst::Kind Inst::getKind(std::string Name) {
                    .Case("bswap", Inst::BSwap)
                    .Case("cttz", Inst::Cttz)
                    .Case("ctlz", Inst::Ctlz)
+                   .Case("fshl", Inst::FShl)
+                   .Case("fshr", Inst::FShr)
                    .Case("sadd.with.overflow", Inst::SAddWithOverflow)
                    .Case("uadd.with.overflow", Inst::UAddWithOverflow)
                    .Case("ssub.with.overflow", Inst::SSubWithOverflow)
@@ -721,6 +727,9 @@ int Inst::getCost(Inst::Kind K) {
     case SRem:
     case URem:
       return 5;
+    case FShl:
+    case FShr:
+      return 3;
     case Select:
       return 3;
     default:

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -585,6 +585,10 @@ bool Parser::typeCheckInst(Inst::Kind IK, unsigned &Width,
   case Inst::Ctlz:
     MaxOps = MinOps = 1;
     break;
+  case Inst::FShl:
+  case Inst::FShr:
+    MaxOps = MinOps = 3;
+    break;
 
   default:
     llvm::report_fatal_error("unhandled");

--- a/lib/Pass/Pass.cpp
+++ b/lib/Pass/Pass.cpp
@@ -318,6 +318,13 @@ public:
       switch (I->K) {
       case Inst::Select:
         return Builder.CreateSelect(V0, V1, V2);
+      case Inst::FShl:
+      case Inst::FShr: {
+        Intrinsic::ID ID =
+            I->K == Inst::FShl ? Intrinsic::fshl : Intrinsic::fshr;
+        Function *F = Intrinsic::getDeclaration(M, ID, T);
+        return Builder.CreateCall(F, {V0, V1, V2});
+      }
       default:
         break;
       }

--- a/test/Infer/README.md
+++ b/test/Infer/README.md
@@ -1,0 +1,5 @@
+This directory is mostly used for testing whether souper can infer some better
+pattern of an souper instructions given some input pattern.
+
+Tests here are mostly written in souper,
+although there are some LLVM IR based tests.

--- a/test/Infer/fshl-as-rotl-nop.ll
+++ b/test/Infer/fshl-as-rotl-nop.ll
@@ -1,0 +1,19 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %souper %solver -souper-infer-nop | %FileCheck %s
+
+declare i64 @llvm.fshl.i64(i64, i64, i64) nounwind readnone
+declare i64 @llvm.fshr.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %a, i64 %n) {
+; CHECK: ; Function: foo
+; CHECK-NEXT: %0:i64 = var
+; CHECK-NEXT: %1:i64 = var
+; CHECK-NEXT: %2:i64 = fshl %0, %0, %1
+; CHECK-NEXT: %3:i64 = fshr %2, %2, %1
+; CHECK-NEXT: cand %3 %0
+
+  %funnelled = call i64 @llvm.fshl.i64(i64 %a, i64 %a, i64 %n)
+  %refunnelled = call i64 @llvm.fshr.i64(i64 %funnelled, i64 %funnelled, i64 %n)
+  ret i64 %refunnelled
+}

--- a/test/Infer/fshl-as-shl.ll
+++ b/test/Infer/fshl-as-shl.ll
@@ -1,0 +1,18 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %souper %solver -souper-infer-inst -souper-synthesis-comps=and,shl,const | %FileCheck %s
+
+declare i64 @llvm.fshl.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %a, i64 %c) {
+; CHECK: ; Function: foo
+; CHECK-NEXT: %0:i64 = var
+; CHECK-NEXT: %1:i64 = var
+; CHECK-NEXT: %2:i64 = fshl %0, 0:i64, %1
+; CHECK-NEXT: %3:i64 = and 63:i64, %1
+; CHECK-NEXT: %4:i64 = shl %0, %3
+; CHECK-NEXT: cand %2 %4
+
+  %funnelled = call i64 @llvm.fshl.i64(i64 %a, i64 0, i64 %c)
+  ret i64 %funnelled
+}

--- a/test/Infer/fshl-consume-shamt-modulo.ll
+++ b/test/Infer/fshl-consume-shamt-modulo.ll
@@ -1,0 +1,20 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %souper %solver -souper-infer-inst -souper-synthesis-comps=fshl | %FileCheck %s
+
+declare i64 @llvm.fshl.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %a, i64 %b, i64 %n) {
+; CHECK: ; Function: foo
+; CHECK-NEXT: %0:i64 = var
+; CHECK-NEXT: %1:i64 = var
+; CHECK-NEXT: %2:i64 = var
+; CHECK-NEXT: %3:i64 = urem %2, 64:i64
+; CHECK-NEXT: %4:i64 = fshl %0, %1, %3
+; CHECK-NEXT: %5:i64 = fshl %0, %1, %2
+; CHECK-NEXT: cand %4 %5
+
+  %nmodwidth = urem i64 %n, 64
+  %funnelled = call i64 @llvm.fshl.i64(i64 %a, i64 %b, i64 %nmodwidth)
+  ret i64 %funnelled
+}

--- a/test/Infer/fshl-nop.ll
+++ b/test/Infer/fshl-nop.ll
@@ -1,0 +1,16 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %souper %solver -souper-infer-nop | %FileCheck %s
+
+declare i64 @llvm.fshl.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %a, i64 %b) {
+; CHECK: ; Function: foo
+; CHECK-NEXT: %0:i64 = var
+; CHECK-NEXT: %1:i64 = var
+; CHECK-NEXT: %2:i64 = fshl %0, %1, 0:i64
+; CHECK-NEXT: cand %2 %0
+
+  %funnelled = call i64 @llvm.fshl.i64(i64 %a, i64 %b, i64 0)
+  ret i64 %funnelled
+}

--- a/test/Infer/fshl-reduce-const-shamt.ll
+++ b/test/Infer/fshl-reduce-const-shamt.ll
@@ -1,0 +1,20 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %souper %solver -souper-infer-inst -souper-synthesis-comps=fshl,const | %FileCheck %s
+
+; XFAIL: *
+; FIXME: does not seem to try to reduce the constant.
+
+declare i64 @llvm.fshl.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %a, i64 %b) {
+; CHECK: ; Function: foo
+; CHECK-NEXT: %0:i64 = var
+; CHECK-NEXT: %1:i64 = var
+; CHECK-NEXT: %2:i64 = fshl %0, %1, 65:i64
+; CHECK-NEXT: %3:i64 = fshl %0, %1, 1:i64
+; CHECK-NEXT: cand %2 %3
+
+  %funnelled = call i64 @llvm.fshl.i64(i64 %a, i64 %b, i64 65)
+  ret i64 %funnelled
+}

--- a/test/Infer/fshl-reduce-shamt-nop.ll
+++ b/test/Infer/fshl-reduce-shamt-nop.ll
@@ -1,0 +1,20 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %souper %solver -souper-infer-inst -souper-synthesis-comps=fshl | %FileCheck %s
+
+declare i64 @llvm.fshl.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %a, i64 %b, i64 %n) {
+; CHECK: ; Function: foo
+; CHECK-NEXT: %0:i64 = var
+; CHECK-NEXT: %1:i64 = var
+; CHECK-NEXT: %2:i64 = var
+; CHECK-NEXT: %3:i64 = add 64:i64, %2
+; CHECK-NEXT: %4:i64 = fshl %0, %1, %3
+; CHECK-NEXT: %5:i64 = fshl %0, %1, %2
+; CHECK-NEXT: cand %4 %5
+
+  %npluswidth = add i64 %n, 64
+  %funnelled = call i64 @llvm.fshl.i64(i64 %a, i64 %b, i64 %npluswidth)
+  ret i64 %funnelled
+}

--- a/test/Infer/fshr-as-rotr-nop.ll
+++ b/test/Infer/fshr-as-rotr-nop.ll
@@ -1,0 +1,19 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %souper %solver -souper-infer-nop | %FileCheck %s
+
+declare i64 @llvm.fshr.i64(i64, i64, i64) nounwind readnone
+declare i64 @llvm.fshl.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %a, i64 %n) {
+; CHECK: ; Function: foo
+; CHECK-NEXT: %0:i64 = var
+; CHECK-NEXT: %1:i64 = var
+; CHECK-NEXT: %2:i64 = fshr %0, %0, %1
+; CHECK-NEXT: %3:i64 = fshl %2, %2, %1
+; CHECK-NEXT: cand %3 %0
+
+  %funnelled = call i64 @llvm.fshr.i64(i64 %a, i64 %a, i64 %n)
+  %refunnelled = call i64 @llvm.fshl.i64(i64 %funnelled, i64 %funnelled, i64 %n)
+  ret i64 %refunnelled
+}

--- a/test/Infer/fshr-as-shr.ll
+++ b/test/Infer/fshr-as-shr.ll
@@ -1,0 +1,18 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %souper %solver -souper-infer-inst -souper-synthesis-comps=and,lshr,const | %FileCheck %s
+
+declare i64 @llvm.fshr.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %b, i64 %c) {
+; CHECK: ; Function: foo
+; CHECK-NEXT: %0:i64 = var
+; CHECK-NEXT: %1:i64 = var
+; CHECK-NEXT: %2:i64 = fshr 0:i64, %0, %1
+; CHECK-NEXT: %3:i64 = and 63:i64, %1
+; CHECK-NEXT: %4:i64 = lshr %0, %3
+; CHECK-NEXT: cand %2 %4
+
+  %funnelled = call i64 @llvm.fshr.i64(i64 0, i64 %b, i64 %c)
+  ret i64 %funnelled
+}

--- a/test/Infer/fshr-consume-shamt-modulo.ll
+++ b/test/Infer/fshr-consume-shamt-modulo.ll
@@ -1,0 +1,20 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %souper %solver -souper-infer-inst -souper-synthesis-comps=fshr | %FileCheck %s
+
+declare i64 @llvm.fshr.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %a, i64 %b, i64 %n) {
+; CHECK: ; Function: foo
+; CHECK-NEXT: %0:i64 = var
+; CHECK-NEXT: %1:i64 = var
+; CHECK-NEXT: %2:i64 = var
+; CHECK-NEXT: %3:i64 = urem %2, 64:i64
+; CHECK-NEXT: %4:i64 = fshr %0, %1, %3
+; CHECK-NEXT: %5:i64 = fshr %0, %1, %2
+; CHECK-NEXT: cand %4 %5
+
+  %nmodwidth = urem i64 %n, 64
+  %funnelled = call i64 @llvm.fshr.i64(i64 %a, i64 %b, i64 %nmodwidth)
+  ret i64 %funnelled
+}

--- a/test/Infer/fshr-nop.ll
+++ b/test/Infer/fshr-nop.ll
@@ -1,0 +1,16 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %souper %solver -souper-infer-nop | %FileCheck %s
+
+declare i64 @llvm.fshr.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %a, i64 %b) {
+; CHECK: ; Function: foo
+; CHECK-NEXT: %0:i64 = var
+; CHECK-NEXT: %1:i64 = var
+; CHECK-NEXT: %2:i64 = fshr %0, %1, 0:i64
+; CHECK-NEXT: cand %2 %1
+
+  %funnelled = call i64 @llvm.fshr.i64(i64 %a, i64 %b, i64 0)
+  ret i64 %funnelled
+}

--- a/test/Infer/fshr-reduce-const-shamt.ll
+++ b/test/Infer/fshr-reduce-const-shamt.ll
@@ -1,0 +1,20 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %souper %solver -souper-infer-inst -souper-synthesis-comps=fshr,const | %FileCheck %s
+
+; XFAIL: *
+; FIXME: does not seem to try to reduce the constant.
+
+declare i64 @llvm.fshr.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %a, i64 %b) {
+; CHECK: ; Function: foo
+; CHECK-NEXT: %0:i64 = var
+; CHECK-NEXT: %1:i64 = var
+; CHECK-NEXT: %2:i64 = fshr %0, %1, 65:i64
+; CHECK-NEXT: %3:i64 = fshr %0, %1, 1:i64
+; CHECK-NEXT: cand %2 %3
+
+  %funnelled = call i64 @llvm.fshr.i64(i64 %a, i64 %b, i64 65)
+  ret i64 %funnelled
+}

--- a/test/Infer/fshr-reduce-shamt-nop.ll
+++ b/test/Infer/fshr-reduce-shamt-nop.ll
@@ -1,0 +1,20 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %souper %solver -souper-infer-inst -souper-synthesis-comps=fshr | %FileCheck %s
+
+declare i64 @llvm.fshr.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %a, i64 %b, i64 %n) {
+; CHECK: ; Function: foo
+; CHECK-NEXT: %0:i64 = var
+; CHECK-NEXT: %1:i64 = var
+; CHECK-NEXT: %2:i64 = var
+; CHECK-NEXT: %3:i64 = add 64:i64, %2
+; CHECK-NEXT: %4:i64 = fshr %0, %1, %3
+; CHECK-NEXT: %5:i64 = fshr %0, %1, %2
+; CHECK-NEXT: cand %4 %5
+
+  %npluswidth = add i64 %n, 64
+  %funnelled = call i64 @llvm.fshr.i64(i64 %a, i64 %b, i64 %npluswidth)
+  ret i64 %funnelled
+}

--- a/test/Pass/README.md
+++ b/test/Pass/README.md
@@ -1,0 +1,5 @@
+This directory is mostly used for testing whether some certain IR (or C/C++)
+pattern does result in souper synthesising some pattern for it.
+
+The simplest case is testing whether the given IR pattern folds into
+an souper instruction.

--- a/test/Pass/syn-inst-fshl-as-rotl-const.ll
+++ b/test/Pass/syn-inst-fshl-as-rotl-const.ll
@@ -1,0 +1,23 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshl,const -S -o - | %FileCheck %s --check-prefix=COSTMODEL
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-ignore-cost -souper-synthesis-comps=fshl,const -S -o - | %FileCheck %s --check-prefix=NOCOSTMODEL
+
+define i32 @rotate(i32 %x) {
+; COSTMODEL: define i32 @rotate(i32 %x) {
+; COSTMODEL-NEXT: %highpart = shl i32 %x, 16
+; COSTMODEL-NEXT: %lowpart = lshr i32 %x, 16
+; COSTMODEL-NEXT: %conv2 = or i32 %highpart, %lowpart
+; COSTMODEL-NEXT: ret i32 %conv2
+; COSTMODEL-NEXT: }
+;
+; NOCOSTMODEL: define i32 @rotate(i32 %x) {
+; NOCOSTMODEL-NEXT: %1 = call i32 @llvm.fshl.i32(i32 %x, i32 %x, i32 16)
+; NOCOSTMODEL-NEXT: ret i32 %1
+; NOCOSTMODEL-NEXT: }
+
+  %highpart = shl i32 %x, 16
+  %lowpart = lshr i32 %x, 16
+  %conv2 = or i32 %highpart, %lowpart
+  ret i32 %conv2
+}

--- a/test/Pass/syn-inst-fshl-as-rotl-safe.ll
+++ b/test/Pass/syn-inst-fshl-as-rotl-safe.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshl -S -o - | %FileCheck %s
+
+define i32 @rotate(i32 %x, i32 %n) {
+; CHECK: define i32 @rotate(i32 %x, i32 %n) {
+; CHECK-NEXT: %1 = call i32 @llvm.fshl.i32(i32 %x, i32 %x, i32 %n)
+; CHECK-NEXT: ret i32 %1
+; CHECK-NEXT: }
+
+  %nmodwidth = and i32 %n, 31
+  %negnmodwidth = sub i32 32, %nmodwidth
+  %highpart = shl i32 %x, %nmodwidth
+  %lowpart = lshr i32 %x, %negnmodwidth
+  %conv2 = or i32 %highpart, %lowpart
+  ret i32 %conv2
+}

--- a/test/Pass/syn-inst-fshl-as-rotl-unsafe.ll
+++ b/test/Pass/syn-inst-fshl-as-rotl-unsafe.ll
@@ -1,0 +1,18 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshl -S -o - | %FileCheck %s
+
+; FIXME: do we really want to synthesize fshl here?
+
+define i32 @rotate(i32 %x, i32 %n) {
+; CHECK: define i32 @rotate(i32 %x, i32 %n) {
+; CHECK-NEXT: %1 = call i32 @llvm.fshl.i32(i32 %x, i32 %x, i32 %n)
+; CHECK-NEXT: ret i32 %1
+; CHECK-NEXT: }
+
+  %negnmodwidth = sub i32 32, %n
+  %highpart = shl i32 %x, %n
+  %lowpart = lshr i32 %x, %negnmodwidth
+  %conv2 = or i32 %highpart, %lowpart
+  ret i32 %conv2
+}

--- a/test/Pass/syn-inst-fshl-normal-const.ll
+++ b/test/Pass/syn-inst-fshl-normal-const.ll
@@ -1,0 +1,23 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshl,const -S -o - | %FileCheck %s --check-prefix=COSTMODEL
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-ignore-cost -souper-synthesis-comps=fshl,const -S -o - | %FileCheck %s --check-prefix=NOCOSTMODEL
+
+define i32 @normal(i32 %a, i32 %b) {
+; COSTMODEL: define i32 @normal(i32 %a, i32 %b) {
+; COSTMODEL-NEXT: %highpart = shl i32 %a, 16
+; COSTMODEL-NEXT: %lowpart = lshr i32 %b, 16
+; COSTMODEL-NEXT: %conv2 = or i32 %highpart, %lowpart
+; COSTMODEL-NEXT: ret i32 %conv2
+; COSTMODEL-NEXT: }
+;
+; NOCOSTMODEL: define i32 @normal(i32 %a, i32 %b) {
+; NOCOSTMODEL-NEXT: %1 = call i32 @llvm.fshl.i32(i32 %a, i32 %b, i32 16)
+; NOCOSTMODEL-NEXT: ret i32 %1
+; NOCOSTMODEL-NEXT: }
+
+  %highpart = shl i32 %a, 16
+  %lowpart = lshr i32 %b, 16
+  %conv2 = or i32 %highpart, %lowpart
+  ret i32 %conv2
+}

--- a/test/Pass/syn-inst-fshl-normal-safe.ll
+++ b/test/Pass/syn-inst-fshl-normal-safe.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshl -S -o - | %FileCheck %s
+
+define i32 @normal(i32 %a, i32 %b, i32 %c) {
+; CHECK: define i32 @normal(i32 %a, i32 %b, i32 %c) {
+; CHECK-NEXT: %1 = call i32 @llvm.fshl.i32(i32 %a, i32 %b, i32 %c)
+; CHECK-NEXT: ret i32 %1
+; CHECK-NEXT: }
+
+  %cmodwidth = and i32 %c, 31
+  %negcmodwidth = sub i32 32, %cmodwidth
+  %highpart = shl i32 %a, %cmodwidth
+  %lowpart = lshr i32 %b, %negcmodwidth
+  %conv2 = or i32 %highpart, %lowpart
+  ret i32 %conv2
+}

--- a/test/Pass/syn-inst-fshl-normal-unsafe.ll
+++ b/test/Pass/syn-inst-fshl-normal-unsafe.ll
@@ -1,0 +1,18 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshl -S -o - | %FileCheck %s
+
+; FIXME: do we really want to synthesize fshl here?
+
+define i32 @normal(i32 %a, i32 %b, i32 %c) {
+; CHECK: define i32 @normal(i32 %a, i32 %b, i32 %c) {
+; CHECK-NEXT: %1 = call i32 @llvm.fshl.i32(i32 %a, i32 %b, i32 %c)
+; CHECK-NEXT: ret i32 %1
+; CHECK-NEXT: }
+
+  %negc = sub i32 32, %c
+  %highpart = shl i32 %a, %c
+  %lowpart = lshr i32 %b, %negc
+  %conv2 = or i32 %highpart, %lowpart
+  ret i32 %conv2
+}

--- a/test/Pass/syn-inst-fshl-wide-const.ll
+++ b/test/Pass/syn-inst-fshl-wide-const.ll
@@ -1,0 +1,18 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshl,const -S -o - | %FileCheck %s
+
+define i32 @naive(i32 %a, i32 %b) {
+; CHECK: define i32 @naive(i32 %a, i32 %b) {
+; CHECK-NEXT: %1 = call i32 @llvm.fshl.i32(i32 %a, i32 %b, i32 16)
+; CHECK-NEXT: ret i32 %1
+; CHECK-NEXT: }
+
+  %widea = zext i32 %a to i64
+  %wideb = zext i32 %b to i64
+  %high = shl i64 %widea, 32
+  %wide = or i64 %high, %wideb
+  %skiplowhalf = lshr i64 %wide, 16
+  %trunc = trunc i64 %skiplowhalf to i32
+  ret i32 %trunc
+}

--- a/test/Pass/syn-inst-fshl-wide.ll
+++ b/test/Pass/syn-inst-fshl-wide.ll
@@ -1,0 +1,21 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshl -S -o - | %FileCheck %s
+
+define i32 @naive(i32 %a, i32 %b, i32 %c) {
+; CHECK: define i32 @naive(i32 %a, i32 %b, i32 %c) {
+; CHECK-NEXT: %1 = call i32 @llvm.fshl.i32(i32 %a, i32 %b, i32 %c)
+; CHECK-NEXT: ret i32 %1
+; CHECK-NEXT: }
+
+  %widea = zext i32 %a to i64
+  %wideb = zext i32 %b to i64
+  %high = shl i64 %widea, 32
+  %wide = or i64 %high, %wideb
+  %cmodwidth = and i32 %c, 31
+  %cmodwidthwide = zext i32 %cmodwidth to i64
+  %shifted = shl i64 %wide, %cmodwidthwide
+  %skiplowhalf = lshr i64 %shifted, 32
+  %trunc = trunc i64 %skiplowhalf to i32
+  ret i32 %trunc
+}

--- a/test/Pass/syn-inst-fshr-as-rotr-const.ll
+++ b/test/Pass/syn-inst-fshr-as-rotr-const.ll
@@ -1,0 +1,23 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshr,const -S -o - | %FileCheck %s --check-prefix=COSTMODEL
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-ignore-cost -souper-synthesis-comps=fshr,const -S -o - | %FileCheck %s --check-prefix=NOCOSTMODEL
+
+define i32 @rotate(i32 %x) {
+; COSTMODEL: define i32 @rotate(i32 %x) {
+; COSTMODEL-NEXT: %highpart = shl i32 %x, 16
+; COSTMODEL-NEXT: %lowpart = lshr i32 %x, 16
+; COSTMODEL-NEXT: %conv2 = or i32 %highpart, %lowpart
+; COSTMODEL-NEXT: ret i32 %conv2
+; COSTMODEL-NEXT: }
+;
+; NOCOSTMODEL: define i32 @rotate(i32 %x) {
+; NOCOSTMODEL-NEXT: %1 = call i32 @llvm.fshr.i32(i32 %x, i32 %x, i32 16)
+; NOCOSTMODEL-NEXT: ret i32 %1
+; NOCOSTMODEL-NEXT: }
+
+  %highpart = shl i32 %x, 16
+  %lowpart = lshr i32 %x, 16
+  %conv2 = or i32 %highpart, %lowpart
+  ret i32 %conv2
+}

--- a/test/Pass/syn-inst-fshr-as-rotr-safe.ll
+++ b/test/Pass/syn-inst-fshr-as-rotr-safe.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshr -S -o - | %FileCheck %s
+
+define i32 @rotate(i32 %x, i32 %n) {
+; CHECK: define i32 @rotate(i32 %x, i32 %n) {
+; CHECK-NEXT: %1 = call i32 @llvm.fshr.i32(i32 %x, i32 %x, i32 %n)
+; CHECK-NEXT: ret i32 %1
+; CHECK-NEXT: }
+
+  %nmodwidth = and i32 %n, 31
+  %negnmodwidth = sub i32 32, %nmodwidth
+  %highpart = shl i32 %x, %negnmodwidth
+  %lowpart = lshr i32 %x, %nmodwidth
+  %conv2 = or i32 %highpart, %lowpart
+  ret i32 %conv2
+}

--- a/test/Pass/syn-inst-fshr-as-rotr-unsafe.ll
+++ b/test/Pass/syn-inst-fshr-as-rotr-unsafe.ll
@@ -1,0 +1,18 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshr -S -o - | %FileCheck %s
+
+; FIXME: do we really want to synthesize fshl here?
+
+define i32 @rotate(i32 %x, i32 %n) {
+; CHECK: define i32 @rotate(i32 %x, i32 %n) {
+; CHECK-NEXT: %1 = call i32 @llvm.fshr.i32(i32 %x, i32 %x, i32 %n)
+; CHECK-NEXT: ret i32 %1
+; CHECK-NEXT: }
+
+  %negnmodwidth = sub i32 32, %n
+  %highpart = shl i32 %x, %negnmodwidth
+  %lowpart = lshr i32 %x, %n
+  %conv2 = or i32 %highpart, %lowpart
+  ret i32 %conv2
+}

--- a/test/Pass/syn-inst-fshr-normal-const.ll
+++ b/test/Pass/syn-inst-fshr-normal-const.ll
@@ -1,0 +1,23 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshr,const -S -o - | %FileCheck %s --check-prefix=COSTMODEL
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-ignore-cost -souper-synthesis-comps=fshr,const -S -o - | %FileCheck %s --check-prefix=NOCOSTMODEL
+
+define i32 @normal(i32 %a, i32 %b) {
+; COSTMODEL: define i32 @normal(i32 %a, i32 %b) {
+; COSTMODEL-NEXT: %highpart = shl i32 %a, 16
+; COSTMODEL-NEXT: %lowpart = lshr i32 %b, 16
+; COSTMODEL-NEXT: %conv2 = or i32 %highpart, %lowpart
+; COSTMODEL-NEXT: ret i32 %conv2
+; COSTMODEL-NEXT: }
+;
+; NOCOSTMODEL: define i32 @normal(i32 %a, i32 %b) {
+; NOCOSTMODEL-NEXT: %1 = call i32 @llvm.fshr.i32(i32 %a, i32 %b, i32 16)
+; NOCOSTMODEL-NEXT: ret i32 %1
+; NOCOSTMODEL-NEXT: }
+
+  %highpart = shl i32 %a, 16
+  %lowpart = lshr i32 %b, 16
+  %conv2 = or i32 %highpart, %lowpart
+  ret i32 %conv2
+}

--- a/test/Pass/syn-inst-fshr-normal-safe.ll
+++ b/test/Pass/syn-inst-fshr-normal-safe.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshr -S -o - | %FileCheck %s
+
+define i32 @normal(i32 %a, i32 %b, i32 %c) {
+; CHECK: define i32 @normal(i32 %a, i32 %b, i32 %c) {
+; CHECK-NEXT: %1 = call i32 @llvm.fshr.i32(i32 %a, i32 %b, i32 %c)
+; CHECK-NEXT: ret i32 %1
+; CHECK-NEXT: }
+
+  %cmodwidth = and i32 %c, 31
+  %negcmodwidth = sub i32 32, %cmodwidth
+  %highpart = shl i32 %a, %negcmodwidth
+  %lowpart = lshr i32 %b, %cmodwidth
+  %conv2 = or i32 %highpart, %lowpart
+  ret i32 %conv2
+}

--- a/test/Pass/syn-inst-fshr-normal-unsafe.ll
+++ b/test/Pass/syn-inst-fshr-normal-unsafe.ll
@@ -1,0 +1,18 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshr -S -o - | %FileCheck %s
+
+; FIXME: do we really want to synthesize fshl here?
+
+define i32 @normal(i32 %a, i32 %b, i32 %c) {
+; CHECK: define i32 @normal(i32 %a, i32 %b, i32 %c) {
+; CHECK-NEXT: %1 = call i32 @llvm.fshr.i32(i32 %a, i32 %b, i32 %c)
+; CHECK-NEXT: ret i32 %1
+; CHECK-NEXT: }
+
+  %negc = sub i32 32, %c
+  %highpart = shl i32 %a, %negc
+  %lowpart = lshr i32 %b, %c
+  %conv2 = or i32 %highpart, %lowpart
+  ret i32 %conv2
+}

--- a/test/Pass/syn-inst-fshr-wide-const.ll
+++ b/test/Pass/syn-inst-fshr-wide-const.ll
@@ -1,0 +1,18 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshr,const -S -o - | %FileCheck %s
+
+define i32 @naive(i32 %a, i32 %b) {
+; CHECK: define i32 @naive(i32 %a, i32 %b) {
+; CHECK-NEXT: %1 = call i32 @llvm.fshr.i32(i32 %a, i32 %b, i32 16)
+; CHECK-NEXT: ret i32 %1
+; CHECK-NEXT: }
+
+  %widea = zext i32 %a to i64
+  %wideb = zext i32 %b to i64
+  %high = shl i64 %widea, 32
+  %wide = or i64 %high, %wideb
+  %shifted = lshr i64 %wide, 16
+  %trunc = trunc i64 %shifted to i32
+  ret i32 %trunc
+}

--- a/test/Pass/syn-inst-fshr-wide.ll
+++ b/test/Pass/syn-inst-fshr-wide.ll
@@ -1,0 +1,20 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as %s -o - | %opt -load %pass -souper -dce %solver -souper-infer-inst -souper-synthesis-comps=fshr -S -o - | %FileCheck %s
+
+define i32 @naive(i32 %a, i32 %b, i32 %c) {
+; CHECK: define i32 @naive(i32 %a, i32 %b, i32 %c) {
+; CHECK-NEXT: %1 = call i32 @llvm.fshr.i32(i32 %a, i32 %b, i32 %c)
+; CHECK-NEXT: ret i32 %1
+; CHECK-NEXT: }
+
+  %widea = zext i32 %a to i64
+  %wideb = zext i32 %b to i64
+  %high = shl i64 %widea, 32
+  %wide = or i64 %high, %wideb
+  %cmodwidth = and i32 %c, 31
+  %cmodwidthwide = zext i32 %cmodwidth to i64
+  %shifted = lshr i64 %wide, %cmodwidthwide
+  %trunc = trunc i64 %shifted to i32
+  ret i32 %trunc
+}

--- a/test/Solver/README.md
+++ b/test/Solver/README.md
@@ -1,0 +1,24 @@
+This directory is pretty much exclusively used for LLVM IR based tests for
+checking whether souper understands equivalency of certain instructions,
+without asking it to synthesize any new instructions.
+
+That is done by placing `, !expected !1` on e.g. `icmp` LLVM IR instructions,
+and adding `!1 = !{i1 1}` at the end of the file.
+
+Example:
+```llvm
+; REQUIRES: solver
+
+; RUN: %llvm-as -o %t %s
+; RUN: %souper %solver -check -souper-infer-iN=false %t
+
+define i32 @foo(i32 %x) {
+entry:
+  %add = add nsw i32 %x, 1
+  %cmp = icmp sgt i32 %add, %x, !expected !1 ; <- `!1` is the unnamed metadata node to use
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+!1 = !{i1 1} ; <- `i1 1` means that we are asserting that `%cmp` should always evaluate `i1 true`
+```

--- a/test/Solver/fshl-as-rotate-const-0.ll
+++ b/test/Solver/fshl-as-rotate-const-0.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as -o %t %s
+; RUN: %souper %solver -check -souper-infer-iN=false %t
+
+declare i8 @llvm.fshl.i8(i8, i8, i8) nounwind readnone
+
+define i8 @foo() {
+entry:                               ; 0xAB    0xAB
+  %funnelled = call i8 @llvm.fshl.i8(i8 171, i8 171, i8 4)
+  ;                            0xBA
+  %cmp = icmp eq i8 %funnelled, 186, !expected !1
+  %conv = zext i1 %cmp to i8
+  ret i8 %conv
+}
+
+!1 = !{i1 1}

--- a/test/Solver/fshl-as-rotate-const-1.ll
+++ b/test/Solver/fshl-as-rotate-const-1.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as -o %t %s
+; RUN: %souper %solver -check -souper-infer-iN=false %t
+
+declare i48 @llvm.fshl.i48(i48, i48, i48) nounwind readnone
+
+define i48 @foo() {
+entry:                            ; 0x000000123456 0x000000123456
+  %funnelled = call i48 @llvm.fshl.i48(i48 1193046,   i48 1193046, i48 32)
+  ;                              0x345600000012
+  %cmp = icmp eq i48 %funnelled, 57543971831826, !expected !1
+  %conv = zext i1 %cmp to i48
+  ret i48 %conv
+}
+
+!1 = !{i1 1}

--- a/test/Solver/fshl-const-0.ll
+++ b/test/Solver/fshl-const-0.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as -o %t %s
+; RUN: %souper %solver -check -souper-infer-iN=false %t
+
+declare i8 @llvm.fshl.i8(i8, i8, i8) nounwind readnone
+
+define i8 @foo() {
+entry:                               ; 0xAA   0x55
+  %funnelled = call i8 @llvm.fshl.i8(i8 170, i8 85, i8 4)
+  ;                            0xA5
+  %cmp = icmp eq i8 %funnelled, 165, !expected !1
+  %conv = zext i1 %cmp to i8
+  ret i8 %conv
+}
+
+!1 = !{i1 1}

--- a/test/Solver/fshl-const-1.ll
+++ b/test/Solver/fshl-const-1.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as -o %t %s
+; RUN: %souper %solver -check -souper-infer-iN=false %t
+
+declare i32 @llvm.fshl.i32(i32, i32, i32) nounwind readnone
+
+define i32 @foo() {
+entry:                                 ; 0x00ABCDEF     0x12345678
+  %funnelled = call i32 @llvm.fshl.i32(i32 11259375, i32 305419896, i32 12)
+  ;                              0xBCDEF123
+  %cmp = icmp eq i32 %funnelled, 3168727331, !expected !1
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+!1 = !{i1 1}

--- a/test/Solver/fshl-reduce-const-shamt.ll
+++ b/test/Solver/fshl-reduce-const-shamt.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as -o %t %s
+; RUN: %souper %solver -check -souper-infer-iN=false %t
+
+declare i64 @llvm.fshl.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %a, i64 %b) {
+entry:
+  %funnelled = call i64 @llvm.fshl.i64(i64 %a, i64 %b, i64 65)
+  %betterfunnelled = call i64 @llvm.fshl.i64(i64 %a, i64 %b, i64 1)
+  %cmp = icmp eq i64 %funnelled, %betterfunnelled, !expected !1
+  %conv = zext i1 %cmp to i64
+  ret i64 %conv
+}
+
+!1 = !{i1 1}

--- a/test/Solver/fshr-as-rotate-const-0.ll
+++ b/test/Solver/fshr-as-rotate-const-0.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as -o %t %s
+; RUN: %souper %solver -check -souper-infer-iN=false %t
+
+declare i8 @llvm.fshr.i8(i8, i8, i8) nounwind readnone
+
+define i8 @foo() {
+entry:                               ; 0xAB    0xAB
+  %funnelled = call i8 @llvm.fshr.i8(i8 171, i8 171, i8 4)
+  ;                            0xBA
+  %cmp = icmp eq i8 %funnelled, 186, !expected !1
+  %conv = zext i1 %cmp to i8
+  ret i8 %conv
+}
+
+!1 = !{i1 1}

--- a/test/Solver/fshr-as-rotate-const-1.ll
+++ b/test/Solver/fshr-as-rotate-const-1.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as -o %t %s
+; RUN: %souper %solver -check -souper-infer-iN=false %t
+
+declare i48 @llvm.fshr.i48(i48, i48, i48) nounwind readnone
+
+define i48 @foo() {
+entry:                            ; 0x000000123456 0x000000123456
+  %funnelled = call i48 @llvm.fshr.i48(i48 1193046,   i48 1193046, i48 32)
+  ;                           0x001234560000
+  %cmp = icmp eq i48 %funnelled, 78187462656, !expected !1
+  %conv = zext i1 %cmp to i48
+  ret i48 %conv
+}
+
+!1 = !{i1 1}

--- a/test/Solver/fshr-const-0.ll
+++ b/test/Solver/fshr-const-0.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as -o %t %s
+; RUN: %souper %solver -check -souper-infer-iN=false %t
+
+declare i8 @llvm.fshr.i8(i8, i8, i8) nounwind readnone
+
+define i8 @foo() {
+entry:                               ; 0xAA   0x55
+  %funnelled = call i8 @llvm.fshr.i8(i8 170, i8 85, i8 4)
+  ;                            0xA5
+  %cmp = icmp eq i8 %funnelled, 165, !expected !1
+  %conv = zext i1 %cmp to i8
+  ret i8 %conv
+}
+
+!1 = !{i1 1}

--- a/test/Solver/fshr-const-1.ll
+++ b/test/Solver/fshr-const-1.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as -o %t %s
+; RUN: %souper %solver -check -souper-infer-iN=false %t
+
+declare i32 @llvm.fshr.i32(i32, i32, i32) nounwind readnone
+
+define i32 @foo() {
+entry:                                 ; 0x00ABCDEF     0x12345678
+  %funnelled = call i32 @llvm.fshr.i32(i32 11259375, i32 305419896, i32 12)
+  ;                              0xDEF12345
+  %cmp = icmp eq i32 %funnelled, 3740345157, !expected !1
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+!1 = !{i1 1}

--- a/test/Solver/fshr-reduce-const-shamt.ll
+++ b/test/Solver/fshr-reduce-const-shamt.ll
@@ -1,0 +1,17 @@
+; REQUIRES: solver
+
+; RUN: %llvm-as -o %t %s
+; RUN: %souper %solver -check -souper-infer-iN=false %t
+
+declare i64 @llvm.fshr.i64(i64, i64, i64) nounwind readnone
+
+define i64 @foo(i64 %a, i64 %b) {
+entry:
+  %funnelled = call i64 @llvm.fshr.i64(i64 %a, i64 %b, i64 65)
+  %betterfunnelled = call i64 @llvm.fshr.i64(i64 %a, i64 %b, i64 1)
+  %cmp = icmp eq i64 %funnelled, %betterfunnelled, !expected !1
+  %conv = zext i1 %cmp to i64
+  ret i64 %conv
+}
+
+!1 = !{i1 1}

--- a/test/Tool/README.md
+++ b/test/Tool/README.md
@@ -1,0 +1,3 @@
+This directory is pretty much exclusively used for souper based tests for
+checking whether souper understands equivalency of certain instructions,
+without asking it to synthesize any new instructions.

--- a/unittests/Parser/ParserTests.cpp
+++ b/unittests/Parser/ParserTests.cpp
@@ -234,6 +234,48 @@ TEST(ParserTest, Errors) {
       { "%0 = select 1:i1, 2:i32, 3:i64\n",
         "<input>:1:1: operands have different widths" },
 
+      { "%0 = fshl\n",
+        "<input>:2:1: unexpected token: ''" },
+      { "%0 = fshl 1:i1\n",
+        "<input>:1:1: expected 3 operands, found 1" },
+      { "%0 = fshl 1:i1, 2:i1\n",
+        "<input>:1:1: expected 3 operands, found 2" },
+      { "%0 = fshl 1:i2, 2:i1, 3:i1\n",
+       "<input>:1:1: operands have different widths" },
+      { "%0 = fshl 1:i1, 2:i2, 3:i1\n",
+       "<input>:1:1: operands have different widths" },
+      { "%0 = fshl 1:i1, 2:i1, 3:i2\n",
+       "<input>:1:1: operands have different widths" },
+      { "%0 = fshl 1:i2, 2:i2, 3:i1\n",
+       "<input>:1:1: operands have different widths" },
+      { "%0 = fshl 1:i2, 2:i1, 3:i2\n",
+       "<input>:1:1: operands have different widths" },
+      { "%0 = fshl 1:i1, 2:i2, 3:i2\n",
+       "<input>:1:1: operands have different widths" },
+      { "%0 = fshl 1:i1, 2:i1, 3:i1, 4:i1\n",
+        "<input>:1:1: expected 3 operands, found 4" },
+
+      { "%0 = fshr\n",
+        "<input>:2:1: unexpected token: ''" },
+      { "%0 = fshr 1:i1\n",
+        "<input>:1:1: expected 3 operands, found 1" },
+      { "%0 = fshr 1:i1, 2:i1\n",
+        "<input>:1:1: expected 3 operands, found 2" },
+      { "%0 = fshr 1:i2, 2:i1, 3:i1\n",
+       "<input>:1:1: operands have different widths" },
+      { "%0 = fshr 1:i1, 2:i2, 3:i1\n",
+       "<input>:1:1: operands have different widths" },
+      { "%0 = fshr 1:i1, 2:i1, 3:i2\n",
+       "<input>:1:1: operands have different widths" },
+      { "%0 = fshr 1:i2, 2:i2, 3:i1\n",
+       "<input>:1:1: operands have different widths" },
+      { "%0 = fshr 1:i2, 2:i1, 3:i2\n",
+       "<input>:1:1: operands have different widths" },
+      { "%0 = fshr 1:i1, 2:i2, 3:i2\n",
+       "<input>:1:1: operands have different widths" },
+      { "%0 = fshr 1:i1, 2:i1, 3:i1, 4:i1\n",
+        "<input>:1:1: expected 3 operands, found 4" },
+
       { "%0 = zext 1:i1\n",
         "<input>:1:1: inst must have a width" },
       { "%0:i33 = zext 1:i1, 2:i32\n",
@@ -491,6 +533,38 @@ cand %2 1:i1
 %1:i32 = ctlz %0
 %2:i1 = eq 1:i32, %1
 cand %2 1:i1
+)i",
+      R"i(%0:i32 = var ; 0
+%1:i32 = var ; 1
+%2:i32 = fshl %0, %1, 0:i32
+cand %2 %0
+)i",
+      R"i(%0:i32 = var ; 0
+%1:i32 = var ; 1
+%2:i32 = fshl %0, %1, 32:i32
+cand %2 %0
+)i",
+      R"i(%0:i32 = var ; 0
+%1:i32 = var ; 1
+%2:i32 = fshl %0, %1, 33:i32
+%3:i32 = fshl %0, %1, 1:i32
+cand %2 %3
+)i",
+      R"i(%0:i32 = var ; 0
+%1:i32 = var ; 1
+%2:i32 = fshr %0, %1, 0:i32
+cand %2 %1
+)i",
+      R"i(%0:i32 = var ; 0
+%1:i32 = var ; 1
+%2:i32 = fshr %0, %1, 32:i32
+cand %2 %1
+)i",
+      R"i(%0:i32 = var ; 0
+%1:i32 = var ; 1
+%2:i32 = fshr %0, %1, 33:i32
+%3:i32 = fshr %0, %1, 1:i32
+cand %2 %3
 )i",
       R"i(%0:i32 = var ; 0
 %1:i32 = bswap %0

--- a/utils/souper2llvm.in
+++ b/utils/souper2llvm.in
@@ -57,9 +57,9 @@ instmap = {
 nestedinsts = ["add", "mul", "and", "or", "xor"]
 boolinsts = ["eq", "ne", "ugt", "uge", "ult", "ule", "sgt", "sge", "slt", "sle"]
 towidthinsts = ["sext", "trunc", "zext"];
-intrinsts = ["bswap", "ctpop", "cttz", "ctlz", "sadd.with.overflow",
-             "uadd.with.overflow", "ssub.with.overflow", "usub.with.overflow",
-             "smul.with.overflow", "umul.with.overflow"]
+intrinsts = ["bswap", "ctpop", "cttz", "ctlz", "fshl", "fshr",
+             "sadd.with.overflow", "uadd.with.overflow", "ssub.with.overflow",
+             "usub.with.overflow", "smul.with.overflow", "umul.with.overflow"]
 specialinsts = ["block", "pc", "cand", "infer", "result"]
 
 def parseConst(c):


### PR DESCRIPTION
LangRef: https://releases.llvm.org/7.0.0/docs/LangRef.html#llvm-fshl-intrinsic

```
The ‘llvm.fshl’/‘llvm.fshr’ family of intrinsic functions performs
a funnel shift left/right: the first two values are concatenated
as { %a : %b } (%a is the most significant bits of the wide value),
the combined value is shifted left/right,
and the most/least significant bits are extracted to produce a result
that is the same size as the original arguments.
<...>
For vector types, the operation occurs for each element of the vector.
The shift argument is treated as an unsigned amount modulo
the element size of the arguments.
```

Observations:
* If first and second arguments are the same, it's just a normal rotate.
* If it's ‘llvm.fshl’, and second argument is `0`, it's just `shl`.
* If it's ‘llvm.fshr’, and first argument is `0`, it's just `lshr`.
* If it's ‘llvm.fshl’, and third argument is `0`, it's just first argument.
* If it's ‘llvm.fshr’, and third argument is `0`, it's just second argument.

Doubts:
* Do we really want to be this aggressive in synthesizing `fshl`/`fshr`?
  Currently, i tuned `Inst::getCost()` to synthesize it in all the cases
  covered in newly-added `test/Pass/` tests.
* I did not check exhaustive synthesis (no tests).
* First real patch to souper, i'm sure i have missed things,
  or failed at test coverage.

Bugs:
* If the shift amount is constant, even though
  `InstSynthesis::createCleanInst()` does reduce the value of that
  constant (makes it modulo bitwidth), it does not want to use this
  replacement, since the cost is identical.

Bonus:
* Added some docs to the `test/*/README.md` with my understanding of
  what test should be put where.

CC @rotateright