### PR TITLE
cmake: fix trailing whitespaces when appending llvm-config system-libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 set(LLVM_LIBS "${LLVM_LIBS} ${LLVM_SYSTEM_LIBS}")
+string(STRIP ${LLVM_LIBS} LLVM_LIBS)
 
 execute_process(
   COMMAND ${LLVM_CONFIG_EXECUTABLE} --ldflags


### PR DESCRIPTION
In latest cmake version, having any trailing whitespaces in library
names is an error according to CMP0004[1].

This situation can arise when llvm-config --system-libs returns nothing;
hence, appending a whitespace to already defined LLVM_LIBS.

[1] https://cmake.org/cmake/help/v3.0/policy/CMP0004.html