### PR TITLE
Mark the blockpc5.opt as UNSUPPORTED instead of XFAIL

### DIFF
--- a/test/Infer/blockpc5.opt
+++ b/test/Infer/blockpc5.opt
@@ -9,9 +9,9 @@
 ; ExhaustiveSynthesis: sub 210:i32, %1
 ; InstSynthesis: sub 210:i32, %1
 
-; XFAIL: *
+; UNSUPPORTED
 
-; XFAIL until blockpc is supported by ExhaustiveSynthesis. InstSynthesis passes the case correctly.
+; mark this case UNSUPPORTED until blockpc is supported by ExhaustiveSynthesis. InstSynthesis passes the case correctly.
 
 %0 = block 2
 %1:i32 = var


### PR DESCRIPTION
The assertion will not be triggered in debug mode and this test cases passes if the assertion is disabled. If a test is actually passing and it is marked XFAIL, then lit will report failure. 
So, instead of marking the case XFAIL, let's make it UNSUPPORTED until blockpc is supported in exhaustive synthesis.