### PR TITLE
remove variables not used.

### DIFF
--- a/lib/Infer/ExhaustiveSynthesis.cpp
+++ b/lib/Infer/ExhaustiveSynthesis.cpp
@@ -684,8 +684,6 @@ findSatisfyingConstantMap(SynthesisContext &SC, InstConstList &BadConsts,
   // avoid choices for constants that have not worked out in previous iterations
   // ((R1 != C11 ) \/ (R2 != C21 )) /\ ((R1 != C12 ) \/ (R2 != C22 )) /\ ...
   std::error_code EC;
-  std::map<Inst *, Inst *> InstCache;
-  std::map<Block *, Block *> BlockCache;
   std::map<Inst *, llvm::APInt> ConstMap;
 
   Inst *AvoidConsts = SC.IC.getConst(APInt(1, true));


### PR DESCRIPTION
Hi all,
There are two variables which is not used found by Qihoo360 CodeSafe Team.
Details as bellow:

Variables 'InstCache' and 'BlockCache' declared in function findSatisfyingConstantMap() is not used yet.
Variables which has the same name declared in for scope in line 729 and 730 are used instead.

Cheers
Qihoo360 CodeSafe Team