### PR TITLE
Fix: Always create new copy of reservedconst when doing wiring in multiple instruction synthesis

### DIFF
--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -1042,7 +1042,13 @@ Inst *souper::instJoin(Inst *I, Inst *EmptyInst, Inst *NewInst,
   if (I == EmptyInst) {
     Copy = NewInst;
   } else if (I->K == Inst::Var) {
-    Copy = I;
+    if (I->Name.find(ReservedConstPrefix) != std::string::npos) {
+      Copy = IC.createVar(I->Width, I->Name, I->Range, I->KnownZeros,
+                          I->KnownOnes, I->NonZero, I->NonNegative,
+                          I->PowOfTwo, I->Negative, I->NumSignBits);
+    } else {
+      Copy = I;
+    }
   } else {
     Copy = IC.getInst(I->K, I->Width, Ops);
   }


### PR DESCRIPTION
Before the fix, C1 below points the same reservedconst Inst::Var object:
```

Inst1 C1  Inst2 C1
  \  /      \  /
  mul        mul
```

This is wrong. The cache in getInstCopy() when filling in constants after first query might hit the wrong value. This patch gurantees C1 and C2 always point to different objects.

This patch also fixes a potential error: when creating an unary inst or a select inst with a reservedinst as its argument, always call getReservedInst() for a new object. Again, this keeps the cache from breaking things. Binary operators are already following this.