### PR TITLE
docs: Remove HTML_DYNAMIC_MENUS= option

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1234,7 +1234,7 @@ HTML_TIMESTAMP         = NO
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_DYNAMIC_MENUS     = YES
+#HTML_DYNAMIC_MENUS     = YES
 
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the
@@ -1242,7 +1242,7 @@ HTML_DYNAMIC_MENUS     = YES
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_DYNAMIC_SECTIONS  = NO
+#HTML_DYNAMIC_SECTIONS  = NO
 
 # With HTML_INDEX_NUM_ENTRIES one can control the preferred number of entries
 # shown in the various tree structured indices initially; the user can expand


### PR DESCRIPTION
This is not supported in older version of Doxygen. We don't need it; so, let's just remove this option from the config file as it gives annoying warning with older versions.