### PR TITLE
tests: tweak overflow tests to do something useful

### DIFF
--- a/test/Solver/overflow1.ll
+++ b/test/Solver/overflow1.ll
@@ -4,13 +4,12 @@
 ; RUN: %souper %solver -check %t
 
 ; Function Attrs: nounwind readnone
-declare { i32, i1 } @llvm.sadd.with.overflow.i32(i32, i32) #1
+declare { i8, i1 } @llvm.sadd.with.overflow.i8(i8, i8)
 
-define i32 @foo(i32 %x) {
+define i1 @foo() {
 entry:
-  %add = call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 %x, i32 1)
-  %sum = extractvalue { i32, i1 } %add, 0
-  %bit = extractvalue { i32, i1 } %add, 1
-  %conv = zext i1 %bit to i32
-  ret i32 %conv
+  %add = call { i8, i1 } @llvm.sadd.with.overflow.i8(i8 125, i8 5)
+  %bit = extractvalue { i8, i1 } %add, 1, !expected !0
+  ret i1 %bit
 }
+!0 = !{ i1 1 }

--- a/test/Solver/overflow2.ll
+++ b/test/Solver/overflow2.ll
@@ -4,13 +4,11 @@
 ; RUN: %souper %solver -check %t
 
 ; Function Attrs: nounwind readnone
-declare { i32, i1 } @llvm.smul.with.overflow.i32(i32, i32) #1
+declare { i8, i1 } @llvm.smul.with.overflow.i8(i8, i8)
 
-define i32 @foo(i32 %x) {
+define i1 @foo() {
 entry:
- %mul = call { i32, i1 } @llvm.smul.with.overflow.i32(i32 %x, i32 1000)
- %product = extractvalue { i32, i1 } %mul, 0
- %bit = extractvalue { i32, i1 } %mul, 1
- %conv = zext i1 %bit to i32
- ret i32 %conv
+ %mul = call { i8, i1 } @llvm.smul.with.overflow.i8(i8 -12, i8 12)
+ %bit = extractvalue { i8, i1 } %mul, 1, !expected !{ i1 1 }
+ ret i1 %bit
 }

--- a/test/Solver/overflow3.ll
+++ b/test/Solver/overflow3.ll
@@ -3,47 +3,12 @@
 ; RUN: %llvm-as -o %t %s
 ; RUN: %souper %solver -check %t
 
-; ModuleID = 'overflow3.ll'
-target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-unknown-linux-gnu"
-
-@x0 = common global i32 0, align 4
-@.src = private unnamed_addr constant [12 x i8] c"overflow3.c\00", align 1
-@0 = private unnamed_addr constant { i16, i16, [6 x i8] } { i16 0, i16 11, [6 x i8] c"'int'\00" }
-@1 = private unnamed_addr global { { [12 x i8]*, i32, i32 }, { i16, i16, [6 x i8] }* } { { [12 x i8]*, i32, i32 } { [12 x i8]* @.src, i32 2, i32 26 }, { i16, i16, [6 x i8] }* @0 }
-
-; Function Attrs: nounwind uwtable
-define i32 @x1() #0 {
-entry:
-  %0 = load i32, i32* @x0, align 4
-  %1 = call { i32, i1 } @llvm.smul.with.overflow.i32(i32 %0, i32 1000)
-  %2 = extractvalue { i32, i1 } %1, 0
-  %3 = extractvalue { i32, i1 } %1, 1
-  %4 = xor i1 %3, true, !nosanitize !1
-  br i1 %4, label %cont, label %handler.mul_overflow, !prof !2, !nosanitize !1
-
-handler.mul_overflow:                             ; preds = %entry
-  %5 = zext i32 %0 to i64, !nosanitize !1
-  call void @__ubsan_handle_mul_overflow(i8* bitcast ({ { [12 x i8]*, i32, i32 }, { i16, i16, [6 x i8] }* }* @1 to i8*), i64 %5, i64 1000) #3, !nosanitize !1
-  br label %cont, !nosanitize !1
-
-cont:                                             ; preds = %handler.mul_overflow, %entry
-  ret i32 %2
-}
-
 ; Function Attrs: nounwind readnone
-declare { i32, i1 } @llvm.smul.with.overflow.i32(i32, i32) #1
+declare { i8, i1 } @llvm.umul.with.overflow.i8(i8, i8)
 
-; Function Attrs: uwtable
-declare void @__ubsan_handle_mul_overflow(i8*, i64, i64) #2
-
-attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { nounwind readnone }
-attributes #2 = { uwtable }
-attributes #3 = { nounwind }
-
-!llvm.ident = !{!0}
-
-!0 = !{!"clang version 3.7.0 (trunk 228761)"}
-!1 = !{}
-!2 = !{!"branch_weights", i32 1048575, i32 1}
+define i1 @foo() {
+entry:
+ %mul = call { i8, i1 } @llvm.umul.with.overflow.i8(i8 16, i8 16)
+ %bit = extractvalue { i8, i1 } %mul, 1, !expected !{ i1 1 }
+ ret i1 %bit
+}

--- a/test/Solver/overflow4.ll
+++ b/test/Solver/overflow4.ll
@@ -1,60 +1,14 @@
 ; REQUIRES: solver
 
 ; RUN: %llvm-as -o %t %s
-; RUN: %souper %solver -check -souper-infer-iN=false %t
-
-; ModuleID = 'overflow4.ll'
-target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-unknown-linux-gnu"
-
-@.src = private unnamed_addr constant [12 x i8] c"overflow4.c\00", align 1
-@0 = private unnamed_addr constant { i16, i16, [6 x i8] } { i16 0, i16 11, [6 x i8] c"'int'\00" }
-@1 = private unnamed_addr global { { [12 x i8]*, i32, i32 }, { i16, i16, [6 x i8] }* } { { [12 x i8]*, i32, i32 } { [12 x i8]* @.src, i32 3, i32 56 }, { i16, i16, [6 x i8] }* @0 }
-
-; Function Attrs: nounwind uwtable
-define i32 @x1(i32 %x0) #0 {
-entry:
-  %cmp = icmp ult i32 %x0, 1000
-  br i1 %cmp, label %cond.true, label %cond.false
-
-cond.true:                                        ; preds = %entry
-  %mul = mul i32 %x0, 1000
-  br label %cond.end
-
-cond.false:                                       ; preds = %entry
-  %0 = call { i32, i1 } @llvm.ssub.with.overflow.i32(i32 0, i32 1)
-  %1 = extractvalue { i32, i1 } %0, 0
-  %2 = extractvalue { i32, i1 } %0, 1, !expected !3
-  %3 = xor i1 %2, true, !nosanitize !1, !expected !4
-  br i1 %3, label %cont, label %handler.negate_overflow, !prof !2, !nosanitize !1
-
-handler.negate_overflow:                          ; preds = %cond.false
-  call void @__ubsan_handle_negate_overflow(i8* bitcast ({ { [12 x i8]*, i32, i32 }, { i16, i16, [6 x i8] }* }* @1 to i8*), i64 1) #3, !nosanitize !1
-  br label %cont, !nosanitize !1
-
-cont:                                             ; preds = %handler.negate_overflow, %cond.false
-  br label %cond.end
-
-cond.end:                                         ; preds = %cont, %cond.true
-  %cond = phi i32 [ %mul, %cond.true ], [ %1, %cont ]
-  ret i32 %cond
-}
+; RUN: %souper %solver -check %t
 
 ; Function Attrs: nounwind readnone
-declare { i32, i1 } @llvm.ssub.with.overflow.i32(i32, i32) #1
+declare { i8, i1 } @llvm.usub.with.overflow.i8(i8, i8)
 
-; Function Attrs: uwtable
-declare void @__ubsan_handle_negate_overflow(i8*, i64) #2
-
-attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { nounwind readnone }
-attributes #2 = { uwtable }
-attributes #3 = { nounwind }
-
-!llvm.ident = !{!0}
-
-!0 = !{!"clang version 3.7.0 (trunk 228761)"}
-!1 = !{}
-!2 = !{!"branch_weights", i32 1048575, i32 1}
-!3 = !{i1 0}
-!4 = !{i1 1}
+define i1 @foo() {
+entry:
+  %sub = call { i8, i1 } @llvm.usub.with.overflow.i8(i8 0, i8 1)
+  %bit = extractvalue { i8, i1 } %sub, 1, !expected !{ i1 1 }
+  ret i1 %bit
+}

--- a/test/Solver/overflow7.ll
+++ b/test/Solver/overflow7.ll
@@ -4,14 +4,11 @@
 ; RUN: %souper %solver -check %t
 
 ; Function Attrs: nounwind readnone
-declare { i32, i1 } @llvm.ssub.with.overflow.i32(i32, i32) #1
+declare { i8, i1 } @llvm.ssub.with.overflow.i8(i8, i8)
 
-define i32 @foo(i32 %x) {
+define i1 @foo() {
 entry:
-  %cmp1 = icmp ugt i32 %x, 0
-  %sub = call { i32, i1 } @llvm.ssub.with.overflow.i32(i32 0, i32 %x)
-  %bit = extractvalue { i32, i1 } %sub, 1
-  %ret = xor i1 %cmp1, %bit
-  %conv = zext i1 %ret to i32
-  ret i32 %conv
+  %sub = call { i8, i1 } @llvm.ssub.with.overflow.i8(i8 -10, i8 120)
+  %bit = extractvalue { i8, i1 } %sub, 1, !expected !{ i1 1 }
+  ret i1 %bit
 }


### PR DESCRIPTION
There was lot of LLVM IR not related to doing the actual testing of overflow intrinisics. I removed all of it and kept only the part that "actually" checks for the functionality of overflow intrinsics.