### PR TITLE
Pass values from the command line to solver

### DIFF
--- a/include/souper/Infer/Interpreter.h
+++ b/include/souper/Infer/Interpreter.h
@@ -70,11 +70,11 @@ using ValueCache = std::unordered_map<souper::Inst *, EvalValue>;
 
 EvalValue evaluateInst(Inst* Root, ValueCache &Cache);
 llvm::KnownBits findKnownBits(Inst* I, ValueCache& C, bool PartialEval = true);
-llvm::KnownBits findKnownBitsUsingSolver(Inst *I, Solver *S);
+llvm::KnownBits findKnownBitsUsingSolver(Inst *I, Solver *S, std::vector<InstMapping> &PCs);
 llvm::ConstantRange findConstantRange(souper::Inst* I,
                                       souper::ValueCache& C,
                                       bool PartialEval = true);
-llvm::ConstantRange findConstantRangeUsingSolver(souper::Inst* I, Solver *S);
+llvm::ConstantRange findConstantRangeUsingSolver(souper::Inst* I, Solver *S, std::vector<InstMapping> &PCs);
 bool isConcrete(souper::Inst *I, bool ConsiderConsts = true,
                                  bool ConsiderHoles = true);
 std::string knownBitsString(llvm::KnownBits KB);

--- a/lib/Infer/AbstractInterpreter.cpp
+++ b/lib/Infer/AbstractInterpreter.cpp
@@ -507,9 +507,8 @@ namespace souper {
 #undef KB0
 #undef KB1
 
-  llvm::KnownBits findKnownBitsUsingSolver(Inst *I, Solver *S) {
+  llvm::KnownBits findKnownBitsUsingSolver(Inst *I, Solver *S, std::vector<InstMapping> &PCs) {
     BlockPCs BPCs;
-    std::vector<InstMapping> PCs;
     InstContext IC;
     return S->findKnownBitsUsingSolver(BPCs, PCs, I, IC);
   }
@@ -607,7 +606,7 @@ namespace souper {
 #undef CR2
 #undef VAL
 
-  llvm::ConstantRange findConstantRangeUsingSolver(Inst *I, Solver *S) {
+  llvm::ConstantRange findConstantRangeUsingSolver(Inst *I, Solver *S, std::vector<InstMapping> &PCs) {
     // FIXME implement this
     llvm::ConstantRange Result(I->Width);
     return Result;


### PR DESCRIPTION
This is a fallback from #512 

We also need to tell solver the values given by the user in the command line to have accurate results.