### PR TITLE
Allow reservedinst to be given to souper-interpreter

### DIFF
--- a/lib/Extractor/KLEEBuilder.cpp
+++ b/lib/Extractor/KLEEBuilder.cpp
@@ -124,6 +124,7 @@ private:
       assert(0 && "unexpected kind");
     case Inst::Const:
       return klee::ConstantExpr::alloc(I->Val);
+    case Inst::ReservedInst:
     case Inst::Var:
       return makeSizedArrayRead(I->Width, I->Name, I);
     case Inst::Phi: {

--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -503,6 +503,8 @@ Inst::Kind Inst::getKind(std::string Name) {
                    .Case("smul.with.overflow", Inst::SMulWithOverflow)
                    .Case("umul.with.overflow", Inst::UMulWithOverflow)
                    .Case("extractvalue", Inst::ExtractValue)
+                   .Case("reservedinst", Inst::ReservedInst)
+                   .Case("reservedconst", Inst::ReservedConst)
                    .Default(Inst::None);
 }
 
@@ -931,7 +933,8 @@ void souper::findVars(Inst *Root, std::vector<Inst *> &Vars) {
     if (!Visited.insert(I).second)
       continue;
     if (I->K == Inst::Var &&
-        I->Name.find(ReservedConstPrefix) == std::string::npos) {
+        (I->Name.find(ReservedConstPrefix) == std::string::npos &&
+	 I->Name.find(ReservedInstPrefix) == std::string::npos)) {
       Vars.push_back(I);
     }
     for (auto Op : I->Ops)

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -1254,6 +1254,10 @@ bool Parser::parseLine(std::string &ErrStr) {
           return false;
         }
         if (!consumeToken(ErrStr)) return false;
+      } else if (IK == Inst::ReservedInst) {
+        Inst *I = IC.getReservedInst(InstWidth);
+        Context.setInst(InstName, I);
+        return true;
       }
 
       std::vector<Inst *> Ops;

--- a/test/Infer/Interpreter/hole-kb-cr.opt
+++ b/test/Infer/Interpreter/hole-kb-cr.opt
@@ -1,0 +1,13 @@
+; RUN: %souper-interpret %solver -input-values=%0=0 %s > %t 2>&1
+; RUN: %FileCheck %s < %t
+
+; CHECK: KnownBits result:
+; CHECK-NEXT: 00000000
+
+; CHECK: ConstantRange result:
+; CHECK-NEXT: [0,1)
+
+%0:i8 = var
+%1:i8 = reservedinst
+%2 = mul %1, %0
+infer %2

--- a/test/Infer/Interpreter/hole-kb.opt
+++ b/test/Infer/Interpreter/hole-kb.opt
@@ -1,0 +1,10 @@
+; RUN: %souper-interpret %solver -input-values=%0=1 %s > %t 2>&1
+; RUN: %FileCheck %s < %t
+
+; CHECK: KnownBits result:
+; CHECK-NEXT: ???????0
+
+%0:i8 = var
+%1:i8 = reservedinst
+%2 = shl %1, %0
+infer %2

--- a/tools/souper-interpret.cpp
+++ b/tools/souper-interpret.cpp
@@ -171,16 +171,16 @@ static int Interpret(const MemoryBufferRef &MB, Solver *S) {
 
     switch(compareKnownBits(KB, KBSolver)) {
     case CompareDataflowResult::SAME:
-      llvm::errs() << "Same precision.\n";
+      llvm::outs() << "Same precision.\n";
       break;
     case CompareDataflowResult::LESS:
-      llvm::errs() << "Dataflow is less precise than solver.\n";
+      llvm::outs() << "Dataflow is less precise than solver.\n";
       break;
     case CompareDataflowResult::GREATER:
-      llvm::errs() << "Dataflow is more precise than solver.\n";
+      llvm::outs() << "Dataflow is more precise than solver.\n";
       break;
     case CompareDataflowResult::INCOMPARABLE:
-      llvm::errs() << "Reults are incomparable.\n";
+      llvm::outs() << "Reults are incomparable.\n";
       break;
     }
 
@@ -192,13 +192,13 @@ static int Interpret(const MemoryBufferRef &MB, Solver *S) {
     llvm::outs() << "ConstantRange result using solver: \n" << CRSolver << "\n\n";
 
     if (CR == CRSolver)
-      llvm::errs() << "Same precision.\n";
+      llvm::outs() << "Same precision.\n";
     else if (CR.contains(CRSolver))
-      llvm::errs() << "Dataflow is less precise than solver.\n";
+      llvm::outs() << "Dataflow is less precise than solver.\n";
     else if (CRSolver.contains(CR))
-      llvm::errs() << "Dataflow is more precise than solver.\n";
+      llvm::outs() << "Dataflow is more precise than solver.\n";
     else
-      llvm::errs() << "Reults are incomparable.\n";
+      llvm::outs() << "Reults are incomparable.\n";
 
     if (isConcrete(Rep.Mapping.LHS)) {
       llvm::outs() << " -------- Concrete Interpreter ----------- \n";


### PR DESCRIPTION
This modifies the parser to read reservedinst correctly. So following thing is parsed correctly now:

`%0:i32 = reservedinst` 

as an instruction of Kind ReservedInst.

I also had to modify the KLEE backend to treat these instructions of ReservedInst like any other variable. I think this is correct but shout if not.
