### PR TITLE
add support for generating dot format for souper IR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ add_library(souperInfer STATIC
 set(SOUPER_INST_FILES
   lib/Inst/Inst.cpp
   include/souper/Inst/Inst.h
+  include/souper/Inst/InstGraph.h
 )
 
 add_library(souperInst STATIC

--- a/include/souper/Inst/InstGraph.h
+++ b/include/souper/Inst/InstGraph.h
@@ -1,0 +1,88 @@
+// Copyright 2019 The Souper Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOUPER_INSTGRAPH_H
+#define SOUPER_INSTGRAPH_H
+
+#include <string>
+#include <set>
+
+#include "souper/Inst/Inst.h"
+
+#include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/ADT/GraphTraits.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/DOTGraphTraits.h"
+
+template<> struct llvm::GraphTraits<souper::Inst*> {
+  using NodeRef = souper::Inst*;
+
+  static NodeRef getEntryNode(souper::Inst* instr) { return instr; }
+
+  using ChildIteratorType = std::vector<NodeRef>::iterator;
+
+  static ChildIteratorType child_begin(NodeRef N) {
+    return N->Ops.begin();
+  }
+
+  static ChildIteratorType child_end(NodeRef N) {
+    return N->Ops.end();
+  }
+
+  using nodes_iterator = llvm::df_iterator<NodeRef>;
+
+  static nodes_iterator nodes_begin(souper::Inst* I) {
+    return nodes_iterator::begin(getEntryNode(I));
+  }
+
+  static nodes_iterator nodes_end(souper::Inst* I) {
+    return nodes_iterator::end(getEntryNode(I));
+  }
+};
+
+template<> struct llvm::DOTGraphTraits<souper::Inst*> : public llvm::DefaultDOTGraphTraits {
+  DOTGraphTraits(bool isSimple = false) : DefaultDOTGraphTraits(isSimple) {}
+
+  static std::string getGraphName(souper::Inst* instr) { return "Souper IR graph"; }
+
+  std::string getNodeLabel(souper::Inst* instr, souper::Inst* root) {
+    switch(instr->K) {
+    case souper::Inst::Kind::ReservedConst:
+      return "ReservedConst";
+    case souper::Inst::Kind::ReservedInst:
+      return "ReservedInst";
+    case souper::Inst::Kind::Var:
+      return "Var " + instr->Name;
+    case souper::Inst::Kind::Const:
+      return instr->Val.toString(10, false);
+    default:
+      return std::string(souper::Inst::getKindName(instr->K));
+    }
+  }
+
+  static std::string getNodeAttributes(const souper::Inst* instr, const souper::Inst* root) {
+    if (instr == root)
+      return "style=bold";
+
+    return "";
+  }
+
+  static bool renderGraphFromBottomUp() { return true; }
+
+  static std::string getNodeIdentifierLabel(souper::Inst* instr, souper::Inst* root) {
+    return "\"" + std::to_string(reinterpret_cast<intptr_t>(instr)) + "\"";
+  }
+};
+
+#endif

--- a/test/Inst/emit-dot.opt
+++ b/test/Inst/emit-dot.opt
@@ -1,0 +1,16 @@
+; RUN: %souper-check %solver -parse-lhs-only -emit-lhs-dot %s > %t 2>&1
+; RUN: %FileCheck %s < %t
+
+; CHECK: digraph "Souper IR graph"  {
+; CHECK: rankdir="BT";
+; CHECK: label="{mul|
+; CHECK: label="{shl|
+; CHECK: label="{Var 1|
+; CHECK: label="{Var 0|
+; CHECK: label="{6|
+
+%0:i8 = var
+%1:i8 = var
+%2 = shl %1, %0
+%3 = mul %2, 6
+infer %3

--- a/tools/souper-check.cpp
+++ b/tools/souper-check.cpp
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/GraphWriter.h"
+
 #include "souper/Parser/Parser.h"
 #include "souper/Tool/GetSolverFromArgs.h"
+#include "souper/Inst/InstGraph.h"
 
 using namespace llvm;
 using namespace souper;
@@ -51,6 +54,10 @@ static cl::opt<bool> ParseLHSOnly("parse-lhs-only",
     cl::desc("Only parse the LHS, don't call infer() (default=false)"),
     cl::init(false));
 
+static cl::opt<bool> EmitLHSDot("emit-lhs-dot",
+    cl::desc("Emit DOT format DAG for LHS of given souper IR (default=false)"),
+    cl::init(false));
+
 int SolveInst(const MemoryBufferRef &MB, Solver *S) {
   InstContext IC;
   std::string ErrStr;
@@ -66,6 +73,13 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
   if (!ErrStr.empty()) {
     llvm::errs() << ErrStr << '\n';
     return 1;
+  }
+
+  if (EmitLHSDot) {
+    llvm::outs() << "; emitting DOT for parsed LHS souper IR ...\n";
+    for (auto &Rep : Reps) {
+      llvm::WriteGraph(llvm::outs(), Rep.Mapping.LHS);
+    }
   }
 
   if (ParseOnly || ParseLHSOnly) {


### PR DESCRIPTION
./souper-check -emit-lhs-dot now also spits out the dot format of the
souper IR which was parsed which can be used to generate PNG like below:

dot -Tpng test.dot > a.png