### PR TITLE
KLEEBuilder: ugly dirty band-aid hack to workaround recursion. Fixes #400

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ services:
 install:
  - printenv | grep '^TRAVIS_' > my_env
  - docker pull regehr/souperweb:latest
- - docker run --ulimit stack=32768:32768 --env-file my_env -it -d --name souperweb regehr/souperweb bash
+ - docker run --env-file my_env -it -d --name souperweb regehr/souperweb bash
 script:
  - docker exec souperweb /usr/src/souper/clone_and_test.sh


### PR DESCRIPTION
`KLEEBuilder::get()` is recursive.
It already has problems with running out of stack space
with very trivial inputs, since there are a lot of IR instructions
souper knows how to produce, and thus a lot of possible replacements.
(that were returned from `GetCandidateExprForReplacement()`)

But `KLEEBuilder::get()` has built-in caching.
And recursion only kicks in if the `Inst` is not found in cache.
Thus we simply need to *try* to pre-populate the cache.

The caveat here is that if we try to pre-generate `Inst` I,
it will need it's operands to be already generated,
and we are back into recursion business.

Thus, we need to collect all of the `Inst` Operands from every `Inst`
that is reachable from the current 'root' `Inst`, without recursion,
and do pre-generation in reverse order, first processing Defs,
and then Uses. so that when we get to `Inst` I that has Op0 and Op1 ops,
those ops must already be pre-generated.

Note that we can't really split `get()` into `getSimple()` and
`getOrBuildRecursive()` because we won't reach every single one of
these `Inst` because we e.g. won't precompute the `addnswUB()` & friends.

So while this certainly does not replace recursion with a proper work-list,
it should be sufficient to get rid of recursion in 99.99% of cases.

Another startling discovery i have made:
`ExprSMTLIBPrinter` produces SMT query in a string form?!
I have done some rudimentary benchmarks, and that seems to be giant
performance blackhole.
I'm really looking forward moving from KLEE to alive i guess :)

Revert "increase stack a different way"

This reverts commit c490eff970bcf9f447cf2e344a139024719e8f18.

Revert "increase stack for CI"

This reverts commit 89e3fdf445b9685f283541496a14311c7328ba3a.

Revert "increase stack for CI"

This reverts commit 78c8196629d1220a0f185ae1e36d90f5c169535b.