### PR TITLE
Fixed the bug which leads to the misses of Unary operator guesses in exhaustive synthesis

### DIFF
--- a/test/Infer/syn-double-insts/syn-ctpop.opt
+++ b/test/Infer/syn-double-insts/syn-ctpop.opt
@@ -4,7 +4,7 @@
 
 ; synthesis ctpop
 
-; Need 15 min~
+; Need 5 min~
 
 %0:i16 = var
 %1:i16 = and %0, 255:i16


### PR DESCRIPTION
After the trunc/sext/zext patch, syn-ctpop now cost around 5 min.