### PR TITLE
Force static link of Z3 when building third_party llvm

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -76,7 +76,7 @@ patch -d ${llvm_srcdir} -p0 -i $(pwd)/patches/enable-instcombine-switch.patch
 
 mkdir -p $llvm_builddir
 
-cmake_flags=".. -DCMAKE_INSTALL_PREFIX=$llvm_installdir -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=$llvm_build_type -DZ3_INCLUDE_DIR=$z3_installdir/include -DZ3_LIBRARIES=$z3_installdir/lib/libz3.so -DZ3_EXECUTABLE=$z3_installdir/bin/z3"
+cmake_flags=".. -DCMAKE_INSTALL_PREFIX=$llvm_installdir -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=$llvm_build_type -DZ3_INCLUDE_DIR=$z3_installdir/include -DZ3_LIBRARIES=$z3_installdir/lib/libz3.a -DZ3_EXECUTABLE=$z3_installdir/bin/z3"
 
 if [ -n "`which ninja`" ] ; then
   (cd $llvm_builddir && cmake -G Ninja $cmake_flags "$@")


### PR DESCRIPTION
I got some test failures like the following one after a clean build of Souper on a newly installed ubuntu 18.04  machine. The linkage against the custom built Z3 comes from the last patch from @Vsevolod-Livinskij 

```
********************
FAIL: Souper :: Pass/sclang-set.c (155 of 518)
******************** TEST 'Souper :: Pass/sclang-set.c' FAILED ********************
Script:
--
: 'RUN: at line 2';   SOUPER_SOLVER=-z3-path=/home/liuz/work/souper-env/souper/third_party/z3-install/bin/z3 SOUPER_NO_EXTERNAL_CACHE=1 /home/liuz/work/souper-env/build/sclang -O /home/liuz/work/souper-env/souper/test/Pass/sclang-set.c -S -o - -emit-llvm 2>&1 | /home/liuz/work/souper-env/souper/third_party/llvm/Release/bin/FileCheck /home/liuz/work/souper-env/souper/test/Pass/sclang-set.c
--
Exit Code: 1

Command Output (stderr):
--
/home/liuz/work/souper-env/souper/test/Pass/sclang-set.c:3:11: error: CHECK: expected string not found in input
// CHECK: ret i32 -268435456
          ^
<stdin>:1:1: note: scanning from here
/home/liuz/work/souper-env/souper/third_party/llvm/Release/bin/clang: error while loading shared libraries: libz3.so: cannot open shared object file: No such file or directory
^
<stdin>:1:33: note: possible intended match here
/home/liuz/work/souper-env/souper/third_party/llvm/Release/bin/clang: error while loading shared libraries: libz3.so: cannot open shared object file: No such file or directory
                                ^

--
```

Turned it into static link fixed the issue.