### PR TITLE
only update range when the source has the attribute

### DIFF
--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -1213,6 +1213,7 @@ bool Parser::parseLine(std::string &ErrStr) {
                   }
                   if (!consumeToken(ErrStr))
                     return false;
+                  Range = llvm::ConstantRange(Lower, Upper);
                 } else {
                   ErrStr = makeErrStr(TP, "invalid data flow fact type");
                   return false;
@@ -1227,7 +1228,6 @@ bool Parser::parseLine(std::string &ErrStr) {
               ErrStr = makeErrStr(TP, "expected ')' to complete data flow fact");
               return false;
             }
-            Range = llvm::ConstantRange(Lower, Upper);
             if (!consumeToken(ErrStr))
               return false;
           }


### PR DESCRIPTION
The variable range in parser is initialized to full set, however, no matter the source defines the range or not, the variable will be assigned to range [Lower, Upper). Since Lower and Upper are initialized to 0, if source does not define range, the range will be assigned to [0, 0), which is the empty set.
This patch forces it to change the range only when the range is defined in the source file.