### PR TITLE
Fixed a bug which leads to error copy of constant in enumeration synthesize

### DIFF
--- a/include/souper/Inst/Inst.h
+++ b/include/souper/Inst/Inst.h
@@ -295,7 +295,8 @@ Inst *getInstCopy(Inst *I, InstContext &IC,
                   std::map<Inst *, llvm::APInt> *ConstMap,
                   bool CloneVars);
 
-Inst *instJoin(Inst *I, Inst *Reserved, Inst *NewInst, InstContext &IC);
+Inst *instJoin(Inst *I, Inst *Reserved, Inst *NewInst,
+               std::map<Inst *, Inst *> &InstCache, InstContext &IC);
 
 void findVars(Inst *Root, std::vector<Inst *> &Vars);
 

--- a/lib/Infer/ExhaustiveSynthesis.cpp
+++ b/lib/Infer/ExhaustiveSynthesis.cpp
@@ -398,7 +398,8 @@ void getGuesses(std::vector<Inst *> &Guesses,
       JoinedGuess = I;
     else {
       // plugin the new guess I to PrevInst
-      JoinedGuess = instJoin(PrevInst, PrevSlot, I, IC);
+      std::map<Inst *, Inst *> InstCache;
+      JoinedGuess = instJoin(PrevInst, PrevSlot, I, InstCache, IC);
     }
 
     // get all empty slots from the newly plugged inst


### PR DESCRIPTION
The bug is caused by missing handling of Const in instJoin() function. Before the commit the Const is getting copied by getInst, which caused the loss of its value. 

The patch also added the missing cache in instJoin().