### PR TITLE
Simplify enum syn

### DIFF
--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -802,7 +802,6 @@ int Inst::getCost(Inst::Kind K) {
     case UAddSat:
     case SSubSat:
     case USubSat:
-      return 3;
     case Select:
       return 3;
     default:


### PR DESCRIPTION
Okay. I missed this piece of code which was already pruning if both operands are same. It's better to put new saturating and shift operators in this list rather than a new pruning if condition 