### PR TITLE
Separate inferDFA and inferRHS

### DIFF
--- a/test/Infer/precision-kb-1.opt
+++ b/test/Infer/precision-kb-1.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-known-bits %s
+; RUN: %souper-check %solver -infer-known-bits %s
 
 ; CHECK: knownBits from souper: 00000xxx
 

--- a/test/Infer/precision-kb-2.opt
+++ b/test/Infer/precision-kb-2.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-known-bits %s
+; RUN: %souper-check %solver -infer-known-bits %s
 
 ; CHECK: knownBits from souper: xxxxxxx0
 

--- a/test/Infer/precision-kb-3.opt
+++ b/test/Infer/precision-kb-3.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-known-bits %s
+; RUN: %souper-check %solver -infer-known-bits %s
 
 ; CHECK: knownBits from souper: xxx00000
 

--- a/test/Infer/precision-kb-4.opt
+++ b/test/Infer/precision-kb-4.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-known-bits %s
+; RUN: %souper-check %solver -infer-known-bits %s
 
 ; CHECK: knownBits from souper: 0000xxxx
 

--- a/test/Infer/precision-kb-5.opt
+++ b/test/Infer/precision-kb-5.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-known-bits %s
+; RUN: %souper-check %solver -infer-known-bits %s
 
 ; CHECK: knownBits from souper: 00000000000000xxxxxxxxxxxxxxxxxx
 

--- a/test/Infer/precision-neg-1.opt
+++ b/test/Infer/precision-neg-1.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-neg %s
+; RUN: %souper-check %solver -infer-neg %s
 
 ; CHECK: known negative from Souper:   true
 

--- a/test/Infer/precision-neg-2.opt
+++ b/test/Infer/precision-neg-2.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-neg %s
+; RUN: %souper-check %solver -infer-neg %s
 
 ; CHECK: known negative from Souper:   true
 

--- a/test/Infer/precision-nonNeg-1.opt
+++ b/test/Infer/precision-nonNeg-1.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-non-neg %s
+; RUN: %souper-check %solver -infer-non-neg %s
 
 ; CHECK: known nonNegative from Souper:   true
 

--- a/test/Infer/precision-nonNeg-2.opt
+++ b/test/Infer/precision-nonNeg-2.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-non-neg %s
+; RUN: %souper-check %solver -infer-non-neg %s
 
 ; CHECK: known nonNegative from Souper:   true
 

--- a/test/Infer/precision-nonNeg-3.opt
+++ b/test/Infer/precision-nonNeg-3.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-non-neg %s
+; RUN: %souper-check %solver -infer-non-neg %s
 
 ; CHECK: known nonNegative from Souper:   true
 

--- a/test/Infer/precision-nonZero-1.opt
+++ b/test/Infer/precision-nonZero-1.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-non-zero %s
+; RUN: %souper-check %solver -infer-non-zero %s
 
 ; CHECK: known nonZero from Souper:   true
 

--- a/test/Infer/precision-nonZero-2.opt
+++ b/test/Infer/precision-nonZero-2.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-non-zero %s
+; RUN: %souper-check %solver -infer-non-zero %s
 
 ; CHECK: known nonZero from Souper:   true
 

--- a/test/Infer/precision-power-1.opt
+++ b/test/Infer/precision-power-1.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-known-bits %s
+; RUN: %souper-check %solver -infer-known-bits %s
 
 ; CHECK: known powerOfTwo from souper:   true
 

--- a/test/Infer/precision-power-2.opt
+++ b/test/Infer/precision-power-2.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-known-bits %s
+; RUN: %souper-check %solver -infer-known-bits %s
 
 ; CHECK: known powerOfTwo from souper:   true
 

--- a/test/Infer/precision-power-3.opt
+++ b/test/Infer/precision-power-3.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-known-bits %s
+; RUN: %souper-check %solver -infer-known-bits %s
 
 ; CHECK: known powerOfTwo from souper:   true
 

--- a/test/Infer/precision-range-1.opt
+++ b/test/Infer/precision-range-1.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-range -infer-rhs %s | %FileCheck %s
+; RUN: %souper-check %solver -infer-range %s | %FileCheck %s
 
 ; CHECK: known range from souper: [1,0)
 

--- a/test/Infer/precision-range-2.opt
+++ b/test/Infer/precision-range-2.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-range -infer-rhs %s | %FileCheck %s
+; RUN: %souper-check %solver -infer-range %s | %FileCheck %s
 
 ; CHECK: known range from souper: [1,7)
 

--- a/test/Infer/precision-range-3.opt
+++ b/test/Infer/precision-range-3.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-range -infer-rhs %s | %FileCheck %s
+; RUN: %souper-check %solver -infer-range %s | %FileCheck %s
 
 ; isOven(add(and(x, 1), x)) = true
 ; CHECK: known range from souper: [{{0,-1|2,1}})

--- a/test/Infer/precision-range-4.opt
+++ b/test/Infer/precision-range-4.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-range -infer-rhs %s | %FileCheck %s
+; RUN: %souper-check %solver -infer-range %s | %FileCheck %s
 
 ; CHECK: known range from souper: [0,53)
 

--- a/test/Infer/precision-range-5.opt
+++ b/test/Infer/precision-range-5.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-range -infer-rhs %s | %FileCheck %s
+; RUN: %souper-check %solver -infer-range %s | %FileCheck %s
 
 ; CHECK: known range from souper: [1,0)
 

--- a/test/Infer/precision-range-6.opt
+++ b/test/Infer/precision-range-6.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-range -infer-rhs %s | %FileCheck %s
+; RUN: %souper-check %solver -infer-range %s | %FileCheck %s
 
 ; CHECK: known range from souper: [-2147483647,0)
 

--- a/test/Infer/precision-range-7.opt
+++ b/test/Infer/precision-range-7.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-range -infer-rhs %s | %FileCheck %s
+; RUN: %souper-check %solver -infer-range %s | %FileCheck %s
 
 ; CHECK: known range from souper: [0,5)
 

--- a/test/Infer/precision-range-8.opt
+++ b/test/Infer/precision-range-8.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-range -infer-rhs %s | %FileCheck %s
+; RUN: %souper-check %solver -infer-range %s | %FileCheck %s
 
 ; CHECK: known range from souper: [0,129)
 

--- a/test/Infer/precision-range-9.opt
+++ b/test/Infer/precision-range-9.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-range -infer-rhs %s | %FileCheck %s
+; RUN: %souper-check %solver -infer-range %s | %FileCheck %s
 
 ; CHECK: known range from souper: [0,16)
 

--- a/test/Infer/precision-sign-1.opt
+++ b/test/Infer/precision-sign-1.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-sign-bits %s
+; RUN: %souper-check %solver -infer-sign-bits %s
 
 ; CHECK: known signBits from Souper:   56
 

--- a/test/Infer/precision-sign-2.opt
+++ b/test/Infer/precision-sign-2.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check %solver -infer-rhs -infer-sign-bits %s
+; RUN: %souper-check %solver -infer-sign-bits %s
 
 ; CHECK: known signBits from Souper:   16
 

--- a/tools/souper-check.cpp
+++ b/tools/souper-check.cpp
@@ -98,14 +98,16 @@ std::string convertToStr(bool Fact) {
     else
       return "false";
 }
-
+static bool isInferDFA() {
+  return InferNeg || InferNonNeg || InferKnownBits || InferPowerTwo || InferNonZero || InferSignBits || InferRange;
+}
 int SolveInst(const MemoryBufferRef &MB, Solver *S) {
   InstContext IC;
   std::string ErrStr;
 
   std::vector<ParsedReplacement> Reps;
   std::vector<ReplacementContext> Contexts;
-  if (InferRHS || ParseLHSOnly) {
+  if (InferRHS || ParseLHSOnly || isInferDFA()) {
     Reps = ParseReplacementLHSs(IC, MB.getBufferIdentifier(), MB.getBuffer(),
                                 Contexts, ErrStr);
   } else {
@@ -132,101 +134,102 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
   int Ret = 0;
   int Success = 0, Fail = 0, Error = 0;
   for (auto Rep : Reps) {
-    if (InferNeg) {
-      bool Negative;
-      if (std::error_code EC = S->negative(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
-                                           Negative, IC)) {
-        llvm::errs() << "Error: " << EC.message() << '\n';
-        Ret = 1;
-        ++Error;
-      } else {
-        llvm::outs() << "known negative from souper: "
-                     << convertToStr(Negative) << "\n";
+    if (isInferDFA()) {
+      if (InferNeg) {
+        bool Negative;
+        if (std::error_code EC = S->negative(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
+                                             Negative, IC)) {
+          llvm::errs() << "Error: " << EC.message() << '\n';
+          Ret = 1;
+          ++Error;
+        } else {
+          llvm::outs() << "known negative from souper: "
+                       << convertToStr(Negative) << "\n";
+          ++Success;
+        }
+      }
+
+      if (InferNonNeg) {
+        bool NonNegative;
+        if (std::error_code EC = S->nonNegative(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
+                                                NonNegative, IC)) {
+          llvm::errs() << "Error: " << EC.message() << '\n';
+          Ret = 1;
+          ++Error;
+        } else {
+          llvm::outs() << "known nonNegative from souper: "
+                       << convertToStr(NonNegative) << "\n";
+          ++Success;
+        }
+      }
+
+      if (InferKnownBits) {
+        unsigned W = Rep.Mapping.LHS->Width;
+        KnownBits Known(W);
+        if (std::error_code EC = S->knownBits(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
+                                              Known, IC)) {
+          llvm::errs() << "Error: " << EC.message() << '\n';
+          Ret = 1;
+          ++Error;
+        } else {
+          llvm::outs() << "knownBits from souper: "
+                       << Inst::getKnownBitsString(Known.Zero, Known.One) << "\n";
+          ++Success;
+        }
+      }
+
+      if (InferPowerTwo) {
+        bool PowTwo;
+        if (std::error_code EC = S->powerTwo(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
+                                             PowTwo, IC)) {
+          llvm::errs() << "Error: " << EC.message() << '\n';
+          Ret = 1;
+          ++Error;
+        } else {
+          llvm::outs() << "known powerOfTwo from souper: "
+                       << convertToStr(PowTwo) << "\n";
+          ++Success;
+        }
+      }
+
+      if (InferNonZero) {
+        bool NonZero;
+        if (std::error_code EC = S->nonZero(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
+                                            NonZero, IC)) {
+          llvm::errs() << "Error: " << EC.message() << '\n';
+          Ret = 1;
+          ++Error;
+        } else {
+          llvm::outs() << "known nonZero from souper: "
+                       << convertToStr(NonZero) << "\n";
+          ++Success;
+        }
+      }
+
+      if (InferSignBits) {
+        unsigned SignBits;
+        if (std::error_code EC = S->signBits(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
+                                             SignBits, IC)) {
+          llvm::errs() << "Error: " << EC.message() << '\n';
+          Ret = 1;
+          ++Error;
+        } else {
+          llvm::outs() << "known signBits from souper: "
+                       << std::to_string(SignBits) << "\n";
+          ++Success;
+        }
+      }
+
+      if (InferRange) {
+        unsigned W = Rep.Mapping.LHS->Width;
+        llvm::ConstantRange Range = S->constantRange(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS, IC);
+
+        llvm::outs() << "known range from souper: " << "[" << Range.getLower()
+                     << "," << Range.getUpper() << ")" << "\n";
         ++Success;
       }
     }
-
-    if (InferNonNeg) {
-      bool NonNegative;
-      if (std::error_code EC = S->nonNegative(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
-                                              NonNegative, IC)) {
-        llvm::errs() << "Error: " << EC.message() << '\n';
-        Ret = 1;
-        ++Error;
-      } else {
-        llvm::outs() << "known nonNegative from souper: "
-                     << convertToStr(NonNegative) << "\n";
-        ++Success;
-      }
-    }
-
-    if (InferKnownBits) {
-      unsigned W = Rep.Mapping.LHS->Width;
-      KnownBits Known(W);
-      if (std::error_code EC = S->knownBits(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
-                                            Known, IC)) {
-        llvm::errs() << "Error: " << EC.message() << '\n';
-        Ret = 1;
-        ++Error;
-      } else {
-        llvm::outs() << "knownBits from souper: "
-                     << Inst::getKnownBitsString(Known.Zero, Known.One) << "\n";
-        ++Success;
-      }
-    }
-
-    if (InferPowerTwo) {
-      bool PowTwo;
-      if (std::error_code EC = S->powerTwo(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
-                                           PowTwo, IC)) {
-        llvm::errs() << "Error: " << EC.message() << '\n';
-        Ret = 1;
-        ++Error;
-      } else {
-        llvm::outs() << "known powerOfTwo from souper: "
-                     << convertToStr(PowTwo) << "\n";
-        ++Success;
-      }
-    }
-
-    if (InferNonZero) {
-      bool NonZero;
-      if (std::error_code EC = S->nonZero(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
-                                          NonZero, IC)) {
-        llvm::errs() << "Error: " << EC.message() << '\n';
-        Ret = 1;
-        ++Error;
-      } else {
-        llvm::outs() << "known nonZero from souper: "
-                     << convertToStr(NonZero) << "\n";
-        ++Success;
-      }
-    }
-
-    if (InferSignBits) {
-      unsigned SignBits;
-      if (std::error_code EC = S->signBits(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS,
-                                           SignBits, IC)) {
-        llvm::errs() << "Error: " << EC.message() << '\n';
-        Ret = 1;
-        ++Error;
-      } else {
-        llvm::outs() << "known signBits from souper: "
-                     << std::to_string(SignBits) << "\n";
-        ++Success;
-      }
-    }
-
-    if (InferRange) {
-      unsigned W = Rep.Mapping.LHS->Width;
-      llvm::ConstantRange Range = S->constantRange(Rep.BPCs, Rep.PCs, Rep.Mapping.LHS, IC);
-
-      llvm::outs() << "known range from souper: " << "[" << Range.getLower()
-                   << "," << Range.getUpper() << ")" << "\n";
-      ++Success;
-    }
-
-    if (InferRHS || ReInferRHS) {
+    else if (InferRHS || ReInferRHS) {
       int OldCost;
       if (ReInferRHS) {
         OldCost = cost(Rep.Mapping.RHS);


### PR DESCRIPTION
Before this, every DFA query call brings a redundant call to infer-rhs. This patch fixes the issue.