### PR TITLE
Some improvements to gdb pretty printer

### DIFF
--- a/tools/gdbprinter.py
+++ b/tools/gdbprinter.py
@@ -57,7 +57,7 @@ class InstPrinter(object):
             self.print_node(it)
 
         root = stack[-1]
-        nr = self.get_nr(root)
+        nr = self.get_nr(root.address)
         ikind = str(root['K']).split('::')[-1].lower()
         res = '%%%d = %s ' % (nr, ikind)
 
@@ -72,7 +72,7 @@ class InstPrinter(object):
         return '---'
 
 def lookup_type(val):
-    if str(val.type) == 'souper::Inst *':
+    if str(val.type) == 'souper::Inst':
         return InstPrinter(val)
     return None
 


### PR DESCRIPTION
After using it for couple of days, it's useful but it also prints
inst* pointer that appear in backtrace which is annoying sometimes.

Let's change the behavior to print the instruction only when
dereferenced. So you have to do `p *I` to pretty print it, instead of
just doing `p I`