### PR TITLE
Respect MaxNumInstructions parameters more strictly

### DIFF
--- a/include/souper/Inst/Inst.h
+++ b/include/souper/Inst/Inst.h
@@ -270,6 +270,7 @@ struct SynthesisContext {
 };
 
 int cost(Inst *I, bool IgnoreDepsWithExternalUses = false);
+int countHelper(Inst *I, std::set<Inst *> &Visited);
 int instCount(Inst *I);
 int benefit(Inst *LHS, Inst *RHS);
 

--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -904,13 +904,16 @@ int souper::cost(Inst *I, bool IgnoreDepsWithExternalUses) {
 }
 
 
-static int countHelper(Inst *I, std::set<Inst *> &Visited) {
+int souper::countHelper(Inst *I, std::set<Inst *> &Visited) {
   if (!Visited.insert(I).second)
     return 0;
 
   int Count;
 
-  if (I->K == Inst::Var || I->K == Inst::Const || I->K == Inst::Hole)
+  // Main overflow intrinsics has a backing add/sub/mul operation which will be counted as one.
+  // Sub overflow operations ({Add,Sub,Mul}O variants) are not counted as they are not real instructions
+  if (I->K == Inst::Var || I->K == Inst::Const || I->K == Inst::UntypedConst ||
+      Inst::isOverflowIntrinsicMain(I->K) || Inst::isOverflowIntrinsicSub(I->K))
     Count = 0;
   else
     Count = 1;

--- a/test/Infer/pruning-syn-trigger-1.opt
+++ b/test/Infer/pruning-syn-trigger-1.opt
@@ -1,5 +1,5 @@
 ; REQUIRES: solver
-; RUN: %souper-check -infer-rhs -souper-enumerative-synthesis -souper-dataflow-pruning=true %solver %s > %t1
+; RUN: %souper-check -infer-rhs -souper-enumerative-synthesis -souper-dataflow-pruning=true -souper-enumerative-synthesis-num-instructions=2 %solver %s > %t1
 ; RUN: %FileCheck %s < %t1
 
 ; CHECK: [[RETVAL:%[0-9]+]]{{[:i0-9]+}} = sadd.with.overflow %0, %1


### PR DESCRIPTION
The description of this parameter says that it is a way to bound the
maximum number of synthesized instructions but it was never respected.
We were calling instCount on a RHS which will also count the components
reused from the LHS.