### PR TITLE
make extractvalue 2nd arg a 32bit const

### DIFF
--- a/lib/Infer/EnumerativeSynthesis.cpp
+++ b/lib/Infer/EnumerativeSynthesis.cpp
@@ -328,13 +328,13 @@ void getGuesses(std::vector<Inst *> &Guesses,
           auto Comp0 = IC.getInst(Inst::getBasicInstrForOverflow(K), V1->Width, {V1, V2});
           auto Comp1 = IC.getInst(Inst::getOverflowComplement(K), 1, {V1, V2});
           auto Orig = IC.getInst(K, V1->Width + 1, {Comp0, Comp1});
-          N = IC.getInst(Inst::ExtractValue, V1->Width, {Orig, IC.getConst(llvm::APInt(1, 0))});
+          N = IC.getInst(Inst::ExtractValue, V1->Width, {Orig, IC.getConst(llvm::APInt(32, 0))});
         }
         else if (Inst::isOverflowIntrinsicSub(K)) {
           auto Comp0 = IC.getInst(Inst::getBasicInstrForOverflow(Inst::getOverflowComplement(K)), V1->Width, {V1, V2});
           auto Comp1 = IC.getInst(K, 1, {V1, V2});
           auto Orig = IC.getInst(Inst::getOverflowComplement(K), V1->Width + 1, {Comp0, Comp1});
-          N = IC.getInst(Inst::ExtractValue, 1, {Orig, IC.getConst(llvm::APInt(1, 1))});
+          N = IC.getInst(Inst::ExtractValue, 1, {Orig, IC.getConst(llvm::APInt(32, 1))});
         }
         else {
           N = IC.getInst(K, Inst::isCmp(K) ? 1 : Width, {V1, V2});

--- a/test/Infer/pruning-syn-trigger-1.opt
+++ b/test/Infer/pruning-syn-trigger-1.opt
@@ -1,9 +1,9 @@
-; REQUIRES: solver
+; REQUIRES: solver, long-duration-synthesis
 ; RUN: %souper-check -infer-rhs -souper-enumerative-synthesis -souper-dataflow-pruning=true -souper-enumerative-synthesis-num-instructions=2 %solver %s > %t1
 ; RUN: %FileCheck %s < %t1
 
 ; CHECK: [[RETVAL:%[0-9]+]]{{[:i0-9]+}} = sadd.with.overflow %0, %1
-; CHECK: [[RETVAL1:%[0-9]+]]{{[:i0-9]+}} = extractvalue [[RETVAL]], 1:i1
+; CHECK: [[RETVAL1:%[0-9]+]]{{[:i0-9]+}} = extractvalue [[RETVAL]], 1
 ; CHECK: result [[RETVAL1]]
 
 %0:i8 = var

--- a/test/Infer/syn-double-insts/syn-sadd-overflow.opt
+++ b/test/Infer/syn-double-insts/syn-sadd-overflow.opt
@@ -4,7 +4,7 @@
 
 ; synthesis overflow
 ; CHECK: [[RETVAL:%[0-9]+]]{{[:i0-9]+}} = sadd.with.overflow %0, %1
-; CHECK: [[RETVAL1:%[0-9]+]]{{[:i0-9]+}} = extractvalue [[RETVAL]], 1:i1
+; CHECK: [[RETVAL1:%[0-9]+]]{{[:i0-9]+}} = extractvalue [[RETVAL]], 1
 ; CHECK: result [[RETVAL1]]
 %0:i8 = var
 %1:i8 = var


### PR DESCRIPTION
we emit a 32 bit constant when transforming llvm bc to souper IR. so
let's be consistent here as well.