### PR TITLE
Phi should also take poison from their chosen input

### DIFF
--- a/lib/Infer/Interpreter.cpp
+++ b/lib/Infer/Interpreter.cpp
@@ -112,7 +112,7 @@ namespace souper {
         return EvalValue::ub();
 
     // phi and select only take poison from their chosen input
-    if (Inst->K != Inst::Select) {
+    if (Inst->K != Inst::Select && Inst->K != Inst::Phi) {
       for (auto &A : Args)
         if (A.K == EvalValue::ValueKind::Poison)
           return EvalValue::poison();


### PR DESCRIPTION
This fixes the `LLVM ERROR: the model returned from second query evaluates to poison for LHS` bug.