### PR TITLE
Query Structure Fix

### DIFF
--- a/test/Infer/syn-const/issue616.opt
+++ b/test/Infer/syn-const/issue616.opt
@@ -1,0 +1,15 @@
+; REQUIRES: solver, synthesis
+
+; RUN: %souper-check %solver -infer-const  %s > %t
+; RUN: %FileCheck %s < %t
+
+; CHECK: 233:i234
+
+%0:i234 = var ; 1
+%1:i234 = uadd.sat %0, %0
+%2:i234 = sub %1, %0
+infer %2
+%3:i234 = reservedconst
+%4:i234 = ashr %0, %3
+%5:i234 = xor %0, %4
+result %5


### PR DESCRIPTION
This fixes the issue #616.
Consider the first query in constant synthesize CEGIS loop:

```(lhs-ub-free => (lhs != rhs && rhs-ub-free && precondition)) == 0```

This query is problematic: look at the right hand side of the implication, `(lhs != rhs && rhs-ub-free && precondition)`, it is conjunction of three parts: `lhs != rhs`, `rhs-ub-free` and `precondition`. Any one of these three parts evaluating to false will lead to a first query model. Some cases like this one in issue #616, most guesses for the reserved constant leads to poison in RHS, thus `rhs-ub-free` is likely to be false. As a result, most models generated from the first query are garbage and later get discarded in the second query.

The cause of this error is the negation, when the query preprocessor do negation, it is not enough to just negate the `(LHS == RHS)` part, but it needs to negate the whole right hand side of the implication. After applying the negation correctly, the first query looks like

```(lhs-ub-free => (lhs != rhs || !rhs-ub-free || !precondition)) == 0```

The model returned from this new query will not contain any guesses that evaluate to UB in RHS; also it handles the precondition correctly.

In general, this patch can boost the constant synthesize performance when RHS is likely to be evaluated to poison. The attached test case shows the efficiency of the change.