### PR TITLE
DAG matching to prevent joining redundant instructions

### DIFF
--- a/lib/Infer/EnumerativeSynthesis.cpp
+++ b/lib/Infer/EnumerativeSynthesis.cpp
@@ -463,6 +463,10 @@ void getGuesses(std::vector<Inst *> &Guesses,
       JoinedGuess = instJoin(PrevInst, PrevSlot, I, InstCache, IC);
     }
 
+    if (JoinedGuess == nullptr) {
+      continue;
+    }
+
     // get all empty slots from the newly plugged inst
     std::vector<Inst *> CurrSlots;
     getHoles(JoinedGuess, CurrSlots);
@@ -796,7 +800,6 @@ EnumerativeSynthesis::synthesize(SMTLIBSolver *SMTSolver,
   if (Guesses.empty()) {
     return EC;
   }
-
 
   if (UseAlive) {
     return synthesizeWithAlive(SC, RHS, Guesses);

--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -1175,7 +1175,7 @@ Inst *souper::getInstCopy(Inst *I, InstContext &IC,
 }
 
 bool isTerminalInst(Inst *I) {
-  bool terminal = false;
+  bool terminal;
   switch (I->K) {
     case Inst::Const:
     case Inst::UntypedConst:
@@ -1183,6 +1183,9 @@ bool isTerminalInst(Inst *I) {
     case Inst::Phi:
     case Inst::Hole:
       terminal = true;
+      break;
+    default:
+      terminal = false;
   }
 
   return terminal;


### PR DESCRIPTION
We have several pruning rules in our enumerative algorithm that prevents us from enumerating on silly combinations. An example of such a rule would be `sub %0, %0`. The pruning rules work great but these pruning rules are not respected when holes are involved and we have to join two instructions. 

Consider this example:

```
%0:i8 = var ; 0
%1:i1 = hole
%2:i1 = hole
%3:i1 = usub.sat %1, %2
infer %2
```

%1 can take the form of trunc %0 and then %2 can also take the same form afterwards. The problem is that when joining the instruction, the instruction joiner is not smart enough to know that it would lead to a silly instruction at %3 (for which a pruning rule exists) where we will be substracting the same thing from the same thing.

One way to solve this problem which also seems correct is to fix instruction joiner such that whenever a new form is taking the place of a hole, we check if that form has already been present in the current 
candidate. If it's already present, enumerative algorithm should already have taken care of reusing that operand as many times as required or it wouldn't have reused it if pruning rule exist to prevent same operand from being used (like our previous example). 

DAG matching:
To be able to accomplish this, I did a DAG matching in the candidate. I will take the new instruction just generated and try to find if an "equivalent" of it already exists in the candidate containing the hole. All the instruction are matched by their op type and all the terminal insts like reserved const, holes, and variables are matched by their address. If a DAG is found in the tree, we ignore the guess and move on.

This is a O(mn) algorithm where m = number of nodes in haystack DAG and n = number of nodes in needle DAG. Since in our case m and n will mostly be small, we should be fine with this.