### PR TITLE
bump to llvm9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ set(CLANG_INCLUDEDIR "${LLVM_SRC}/tools/clang/include" "${LLVM_BUILD}/tools/clan
 set(ALIVE_DIR "${CMAKE_SOURCE_DIR}/third_party/alive2")
 set(ALIVE_LDFLAGS "-L ${ALIVE_DIR}/build -lalive2")
 
-set(CLANG_LIBS "-lclangCodeGen -lclangTooling -lclangRewrite -lclangFrontend -lclangAnalysis -lclangParse -lclangSerialization -lclangSema -lclangEdit -lclangAnalysis -lclangAST -lclangDriver -lclangLex -lclangBasic")
+set(CLANG_LIBS "-lclangCodeGen -lclangTooling -lclangRewrite -lclangFrontend -lclangAnalysis -lclangParse -lclangSerialization -lclangSema -lclangEdit -lclangAnalysis -lclangAST -lclangDriver -lclangLex -lclangBasic -lclangASTMatchers")
 
 set(GTEST_CXXFLAGS "-DGTEST_HAS_RTTI=0")
 set(GTEST_INCLUDEDIR "${LLVM_SRC}/utils/unittest/googletest/include")

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -21,7 +21,7 @@ fi
 
 # hiredis version 0.14.0
 hiredis_commit=685030652cd98c5414ce554ff5b356dfe8437870
-llvm_branch=tags/RELEASE_800/final
+llvm_branch=tags/RELEASE_900/final
 klee_repo=https://github.com/rsas/klee
 klee_branch=pure-bv-qf-llvm-7.0
 alive_commit=9823174bb34fcb9c8e33c37e7e04d46bfe3a29a5

--- a/include/klee/Config/config.h
+++ b/include/klee/Config/config.h
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#define LLVM_VERSION_MAJOR 8
+#define LLVM_VERSION_MAJOR 9
 #define LLVM_VERSION_MINOR 0

--- a/include/souper/Extractor/Candidates.h
+++ b/include/souper/Extractor/Candidates.h
@@ -109,6 +109,8 @@ FunctionCandidateSet ExtractCandidates(
     llvm::Function *F, InstContext &IC, ExprBuilderContext &EBC,
     const ExprBuilderOptions &Opts = ExprBuilderOptions());
 
+llvm::APInt getSetSize(const llvm::ConstantRange &R);
+
 }
 
 #endif  // SOUPER_EXTRACTOR_CANDIDATES_H

--- a/include/souper/Inst/Inst.h
+++ b/include/souper/Inst/Inst.h
@@ -174,7 +174,7 @@ struct Inst : llvm::FoldingSetNode {
   unsigned SynthesisConstID;
   HarvestType HarvestKind;
   llvm::BasicBlock* HarvestFrom;
-  llvm::ConstantRange Range=llvm::ConstantRange(1);
+  llvm::ConstantRange Range=llvm::ConstantRange(1, true);
   std::vector<llvm::ConstantRange> RangeRefinement;
 };
 

--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -89,6 +89,17 @@ extern bool UseAlive;
 using namespace llvm;
 using namespace souper;
 
+llvm::APInt souper::getSetSize(const llvm::ConstantRange &R) {
+  if (R.isFullSet()) {
+    APInt Size(R.getBitWidth()+1, 0);
+    Size.setBit(R.getBitWidth());
+    return Size;
+  }
+
+  // This is also correct for wrapped sets.
+  return (R.getUpper() - R.getLower()).zext(R.getBitWidth()+1);
+}
+
 void CandidateReplacement::printFunction(llvm::raw_ostream &Out) const {
   assert(Mapping.LHS->hasOrigin(Origin));
   const Function *F = Origin->getParent()->getParent();
@@ -227,7 +238,7 @@ Inst *ExprBuilder::makeArrayRead(Value *V) {
         auto SC = SE->getSCEV(V);
         auto R1 = LVIRange.intersectWith(SE->getSignedRange(SC));
         auto R2 = LVIRange.intersectWith(SE->getUnsignedRange(SC));
-        Range = R1.getSetSize().ult(R2.getSetSize()) ? R1 : R2;
+        Range = getSetSize(R1).ult(getSetSize(R2)) ? R1 : R2;
       }
     }
   }
@@ -868,6 +879,9 @@ std::string convertBoolToStr(bool b) {
 
 void PrintDataflowInfo(Function &F, Instruction &I, LazyValueInfo *LVI,
                        ScalarEvolution *SE) {
+  if (I.getNumOperands() == 0) {
+    return;
+  }
   auto V = I.getOperand(0);
   auto DL = F.getParent()->getDataLayout();
   if (PrintNegAtReturn) {
@@ -911,7 +925,7 @@ void PrintDataflowInfo(Function &F, Instruction &I, LazyValueInfo *LVI,
         auto SC = SE->getSCEV(V);
         auto R1 = LVIRange.intersectWith(SE->getSignedRange(SC));
         auto R2 = LVIRange.intersectWith(SE->getUnsignedRange(SC));
-        Range = R1.getSetSize().ult(R2.getSetSize()) ? R1 : R2;
+        Range = getSetSize(R1).ult(getSetSize(R2)) ? R1 : R2;
       }
     }
     llvm::outs() << "range from compiler: [" << Range.getLower() << ","

--- a/lib/Extractor/Candidates.cpp
+++ b/lib/Extractor/Candidates.cpp
@@ -89,6 +89,7 @@ extern bool UseAlive;
 using namespace llvm;
 using namespace souper;
 
+// LLVM removes this API from version 9, this function is copied from LLVM 8
 llvm::APInt souper::getSetSize(const llvm::ConstantRange &R) {
   if (R.isFullSet()) {
     APInt Size(R.getBitWidth()+1, 0);

--- a/lib/Infer/ConstantSynthesis.cpp
+++ b/lib/Infer/ConstantSynthesis.cpp
@@ -215,7 +215,6 @@ ConstantSynthesis::synthesize(SMTLIBSolver *SMTSolver,
                                                        getInstCopy(Mapping.RHS, IC, InstCache,
                                                                    BlockCache, &SubstConstMap, true)}),
                               SubstAnte});
-      assert(BlockCache.empty());
     }
   }
 

--- a/lib/Infer/EnumerativeSynthesis.cpp
+++ b/lib/Infer/EnumerativeSynthesis.cpp
@@ -599,16 +599,9 @@ std::error_code synthesizeWithAlive(SynthesisContext &SC, Inst *&RHS,
 
 std::error_code isConcreteCandidateSat(SynthesisContext &SC, Inst *RHSGuess, bool &IsSat) {
   std::error_code EC;
-  BlockPCs BPCsCopy;
-  std::vector<InstMapping> PCsCopy;
-  std::map<Inst *, Inst *> InstCache;
-  std::map<Block *, Block *> BlockCache;
-  separateBlockPCs(SC.BPCs, BPCsCopy, InstCache, BlockCache, SC.IC, {}, false);
-  separatePCs(SC.PCs, PCsCopy, InstCache, BlockCache, SC.IC, {}, false);
-
   InstMapping Mapping(SC.LHS, RHSGuess);
 
-  std::string Query2 = BuildQuery(SC.IC, BPCsCopy, PCsCopy, Mapping, 0, 0);
+  std::string Query2 = BuildQuery(SC.IC, SC.BPCs, SC.PCs, Mapping, 0, 0);
 
   EC = SC.SMTSolver->isSatisfiable(Query2, IsSat, 0, 0, SC.Timeout);
   if (EC && DebugLevel > 1) {

--- a/lib/Infer/Pruning.cpp
+++ b/lib/Infer/Pruning.cpp
@@ -14,7 +14,7 @@
 
 #include "souper/Infer/AbstractInterpreter.h"
 #include "souper/Infer/Pruning.h"
-
+#include "souper/Extractor/Candidates.h"
 #include <cstdlib>
 
 namespace souper {
@@ -67,7 +67,7 @@ std::vector<llvm::ConstantRange> constantRangeNarrowing
       // C could be in CR, subdivide
       auto L = CR.getLower();
       auto H = CR.getUpper();
-      auto Size = CR.getSetSize();
+      auto Size = getSetSize(CR);
 
       if (L.ugt(H)) {
         // TODO(manasij): Bisect wrapped ranges instead of giving up.
@@ -349,7 +349,7 @@ bool PruningManager::isInfeasible(souper::Inst *RHS,
 
       size_t ResidualSize = 0;
       for (auto &&R : Rs) {
-        ResidualSize += R.getSetSize().getLimitedValue();
+        ResidualSize += getSetSize(R).getLimitedValue();
       }
 
       if (ResidualSize < 8192 && Rs.size() < 3) {

--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -1219,6 +1219,7 @@ void souper::separateBlockPCs(const BlockPCs &BPCs, BlockPCs &BPCsCopy,
                               bool CloneVars) {
   for (const auto &BPC : BPCs) {
     auto BPCCopy = BPC;
+    assert(BlockCache[BPC.B]);
     BPCCopy.B = BlockCache[BPC.B];
     BPCCopy.PC = InstMapping(getInstCopy(BPC.PC.LHS, IC, InstCache, BlockCache, ConstMap, CloneVars),
                              getInstCopy(BPC.PC.RHS, IC, InstCache, BlockCache, ConstMap, CloneVars));

--- a/test/Pass/nop1.ll
+++ b/test/Pass/nop1.ll
@@ -22,4 +22,3 @@ jmp:
 declare i32 @a(i32) local_unnamed_addr #1
 
 ; CHECK: 1 souper - Number of instructions replaced by another instruction
-; XFAIL: *

--- a/unittests/Interpreter/InterpreterInfra.cpp
+++ b/unittests/Interpreter/InterpreterInfra.cpp
@@ -476,8 +476,7 @@ ConstantRange CRTesting::enumerative(const ConstantRange &L, const ConstantRange
   return bestCR(Table, WIDTH);
 }
 
-void CRTesting::check(const ConstantRange &L, const ConstantRange &R, Inst::Kind pred,
-                      double &FastBits, double &PreciseBits, int &Count, int &PreciseCount) {
+void CRTesting::check(const ConstantRange &L, const ConstantRange &R, Inst::Kind pred) {
   ConstantRange FastRes(WIDTH, true);
   switch (pred) {
   case Inst::Or:
@@ -489,24 +488,8 @@ void CRTesting::check(const ConstantRange &L, const ConstantRange &R, Inst::Kind
   default:
     report_fatal_error("unsupported opcode");
   }
-
   ConstantRange PreciseRes = enumerative(L, R, pred, FastRes);
-
-  long FastSize = FastRes.getSetSize().getLimitedValue();
-  long PreciseSize = PreciseRes.getSetSize().getLimitedValue();
-
-  assert(FastSize >= 0 && FastSize <= (1 << WIDTH));
-  assert(PreciseSize >= 0 && PreciseSize <= (1 << WIDTH));
-  assert(PreciseSize <= FastSize);
-
-  if (FastSize > 0) {
-    FastBits += log2((double)FastSize);
-    Count++;
-  }
-  if (PreciseSize > 0) {
-    PreciseBits += log2((double)PreciseSize);
-    PreciseCount++;
-  }
+  assert(getSetSize(PreciseRes).ule(getSetSize(FastRes)));
 }
 
 ConstantRange CRTesting::nextCR(const ConstantRange &CR) {
@@ -523,11 +506,9 @@ ConstantRange CRTesting::nextCR(const ConstantRange &CR) {
 bool CRTesting::testFn(Inst::Kind pred) {
   ConstantRange L(WIDTH, /*isFullSet=*/false);
   ConstantRange R(WIDTH, /*isFullSet=*/false);
-  double FastBits = 0.0, PreciseBits = 0.0;
-  int Count = 0, PreciseCount = 0;
   do {
     do {
-      check(L, R, pred, FastBits, PreciseBits, Count, PreciseCount);
+      check(L, R, pred);
       R = nextCR(R);
     } while (!R.isEmptySet());
     L = nextCR(L);

--- a/unittests/Interpreter/InterpreterInfra.h
+++ b/unittests/Interpreter/InterpreterInfra.h
@@ -67,8 +67,7 @@ namespace souper {
       llvm::ConstantRange enumerative(const llvm::ConstantRange &L, const llvm::ConstantRange &R,
                                      Inst::Kind pred, const llvm::ConstantRange &Untrusted);
 
-      void check(const llvm::ConstantRange &L, const llvm::ConstantRange &R, Inst::Kind pred,
-                 double &FastBits, double &PreciseBits, int &Count, int &PreciseCount);
+      void check(const llvm::ConstantRange &L, const llvm::ConstantRange &R, Inst::Kind pred);
 
     public:
 


### PR DESCRIPTION
This PR fixes the two failed assertions in separateBPC(). The cause of the assertion failure is because an unnecessary and wrong call to separateBPC() in isConcreteCandidateSat() in EnumerativeSynthesis.cpp.

This PR also fixes an wrong assertion in ConstantSynthesis.cpp. Previously I made a wrong assumption that RHS should never contain phi because we're not synthesizing phis. This is not correct because RHS may use phis harvested from LHS. I removed the assertion in this patch.

All the test cases passed after this patch in a debug build.