### PR TITLE
fix wrapped range check to handle special case in which upper bound is 0

### DIFF
--- a/lib/Extractor/ExprBuilder.cpp
+++ b/lib/Extractor/ExprBuilder.cpp
@@ -382,7 +382,7 @@ Inst *ExprBuilder::getDataflowConditions(Inst *I) {
     if (!CR.isEmptySet() && !CR.isFullSet()) {
       Inst *Lower = LIC->getConst(CR.getLower());
       Inst *Upper = LIC->getConst(CR.getUpper());
-      if (!CR.isWrappedSet()) {
+      if (!CR.isWrappedSet() && !CR.isUpperWrapped()) {
         return LIC->getInst(Inst::And, 1,
                            {LIC->getInst(Inst::Ule, 1, {Lower, I}),
                             LIC->getInst(Inst::Ult, 1, {I, Upper})});

--- a/lib/Infer/AbstractInterpreter.cpp
+++ b/lib/Infer/AbstractInterpreter.cpp
@@ -321,7 +321,8 @@ namespace souper {
 
       APInt umax = APIntOps::umax(LHS.getUnsignedMin(), RHS.getUnsignedMin());
       APInt res = APInt::getNullValue(LHS.getBitWidth());
-      if (!LHS.isWrappedSet() && !RHS.isWrappedSet()) {
+      if (!LHS.isWrappedSet() && !LHS.isUpperWrapped() &&
+          !RHS.isWrappedSet() && !RHS.isUpperWrapped()) {
         APInt umaxupper = APIntOps::umax(LHS.getUnsignedMax(), RHS.getUnsignedMax());
         APInt uminupper = APIntOps::umin(LHS.getUnsignedMax(), RHS.getUnsignedMax());
         res = APInt::getLowBitsSet(LHS.getBitWidth(),
@@ -355,7 +356,8 @@ namespace souper {
       // if there are no zeros from bitPos upto both barriers, lower bound have bit
       // set at bitPos. Barrier is the point beyond which you cannot set the bit
       // because it will be greater than the upper bound then
-      if (!LHS.isWrappedSet() && !RHS.isWrappedSet() &&
+      if (!LHS.isWrappedSet() && !LHS.isUpperWrapped() &&
+          !RHS.isWrappedSet() && !RHS.isUpperWrapped() &&
           (lower1.countLeadingZeros() == upper1.countLeadingZeros()) &&
           (lower2.countLeadingZeros() == upper2.countLeadingZeros()) &&
           bitPos > 0) {

--- a/test/Infer/precision-kb-6.opt
+++ b/test/Infer/precision-kb-6.opt
@@ -1,0 +1,8 @@
+; REQUIRES: solver
+; RUN: %souper-check %solver -infer-known-bits %s | %FileCheck %s
+
+; CHECK: knownBits from souper: 1
+
+%0:i32 = var (range=[1, 0))
+%1 = ne 0, %0
+infer %1


### PR DESCRIPTION
LLVM-9.0 redefined isWrappedSet() as: `Lower.ugt(Upper) && !Upper.isNullValue()`
to ignore the case in which upper bound is zero, and added a new API
isUpperWrapped() as: `Lower.ugt(Upper)`.

However, in LLVM-8.0, isWrappedSet() checked `Lower.ugt(Upper)` to cover all
cases of wrapped range.

For reference, This change was made in the LLVM's commit id: 58c0bdde21ea