### PR TITLE
Use orderedOps in codegen to eliminate the ambiguous generation of commutativity instructions

### DIFF
--- a/test/Pass/syn-2-inst-blsr.ll
+++ b/test/Pass/syn-2-inst-blsr.ll
@@ -12,7 +12,7 @@ define i32 @ia32_Blsr_unsupported(i32) local_unnamed_addr #0 {
   ;CHECK-NOT: %2 = sub i32 0, %0
   ;CHECK-NOT: %3 = or i32 %2, %0
   ;CHECK-NOT: %4 = add i32 %3, %0
-  ;CHECK: %2 = add i32 %0, -1
+  ;CHECK: %2 = add i32 -1, %0
   ;CHECK: %3 = and i32 {{(%0, %2)|(%2, %0)}}
 
 }

--- a/test/Pass/syn-inst-add.ll
+++ b/test/Pass/syn-inst-add.ll
@@ -12,7 +12,7 @@ entry:
   %b = add i32 %a, 1
   ;CHECK-NOT: %c = add i32 %b, 1
   %c = add i32 %b, 1
-  ;CHECK: add i32 %x, 4
+  ;CHECK: add i32 4, %x
   %d = add i32 %c, 1
   ret i32 %d
 }

--- a/test/Pass/syn-inst-and.ll
+++ b/test/Pass/syn-inst-and.ll
@@ -10,6 +10,6 @@ entry:
   %a = and i32 %x, 3 ; 0b011
   ;CHECK-NOT: %b = and i32 %a, 6
   %b = and i32 %a, 6 ;0b110
-  ;CHECK: and i32 %x, 2
+  ;CHECK: and i32 2, %x
   ret i32 %b
 }

--- a/test/Pass/syn-inst-mul.ll
+++ b/test/Pass/syn-inst-mul.ll
@@ -14,6 +14,6 @@ entry:
   %c = mul i32 %b, 3
   ;CHECK-NOT: %d = mul i32 %c, 4
   %d = mul i32 %c, 4
-  ;CHECK: mul i32 %x, 24
+  ;CHECK: mul i32 24, %x
   ret i32 %d
 }

--- a/test/Pass/syn-inst-or.ll
+++ b/test/Pass/syn-inst-or.ll
@@ -10,6 +10,6 @@ entry:
   %a = or i32 %x, 3 ; 0b011
   ;CHECK-NOT: %b = or i32 %a, 6
   %b = or i32 %a, 6 ;0b110
-  ;CHECK: or i32 %x, 7
+  ;CHECK: or i32 7, %x
   ret i32 %b
 }

--- a/test/Pass/syn-inst-xor.ll
+++ b/test/Pass/syn-inst-xor.ll
@@ -10,6 +10,6 @@ entry:
   %a = xor i32 %x, 3 ; 0b011
   ;CHECK-NOT: %b = xor i32 %a, 6
   %b = xor i32 %a, 6 ;0b110
-  ;CHECK: xor i32 %x, 5
+  ;CHECK: xor i32 5, %x
   ret i32 %b
 }


### PR DESCRIPTION
Several test cases fail on OS X due to the ambiguous code generation of commutativity operators. This patch fixes the issue by using Inst::orderedOps instead of the raw operand vector Inst::Ops in LLVM codegen. 

Note that now LLVM code generation of commutativity operators are shaped by the less than operator of souper::Inst. The ordering of operands does not always follow the way LLVM InstCombine canonicalization prefers. For example, the most common canonicalization rule is that if there is a constant in the operand list and the operator is commutative, then place the constant on the RHS. However, the current Souper code will always put the constant on the LHS. This "constant on LHS" ordering is already spread all over the Souper test suite. I can give a patch for fixing that if @regehr agrees that constant should be placed on the RHS.