### PR TITLE
remove the unnecessary libc build in build_deps.sh

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -65,8 +65,6 @@ llvm_builddir=$(pwd)/${llvm_srcdir}/${llvm_build_type}-build
 svn co https://llvm.org/svn/llvm-project/llvm/${llvm_branch} ${llvm_srcdir}
 svn co https://llvm.org/svn/llvm-project/cfe/${llvm_branch} ${llvm_srcdir}/tools/clang
 svn co https://llvm.org/svn/llvm-project/compiler-rt/${llvm_branch} ${llvm_srcdir}/projects/compiler-rt
-svn co https://llvm.org/svn/llvm-project/libcxx/${llvm_branch} ${llvm_srcdir}/projects/libcxx
-svn co https://llvm.org/svn/llvm-project/libcxxabi/${llvm_branch} ${llvm_srcdir}/projects/libcxxabi
 # Disable the broken select -> logic optimizations
 patch ${llvm_srcdir}/lib/Transforms/InstCombine/InstCombineSelect.cpp < patches/disable-instcombine-select-to-logic.patch
 # Apply instcombine switch patch


### PR DESCRIPTION
The script build_deps.sh failed when building llvm/libc on freebsd. I found out that libc is not used in Souper, so I just removed it from build_deps.sh. Test suite ran good on osx, ubuntu and freebsd on both debug and release for this patch.