### PR TITLE
Fix memory corruption

### DIFF
--- a/lib/Infer/EnumerativeSynthesis.cpp
+++ b/lib/Infer/EnumerativeSynthesis.cpp
@@ -359,7 +359,7 @@ bool getGuesses(const std::vector<Inst *> &Inputs,
           continue;
 
         // PRUNE: don't synthesize sub x, C since this is covered by add x, -C
-        if (K == Inst::Sub && V2->SynthesisConstID != 0)
+        if (K == Inst::Sub && V2->K == Inst::Var && V2->SynthesisConstID != 0)
           continue;
 
         Inst *N = nullptr;


### PR DESCRIPTION
Field SynthesisConstID get initialized only when the Inst is a Var.