### PR TITLE
Pruning with partially restricted bits and abstract input specialization

### DIFF
--- a/include/souper/Infer/Pruning.h
+++ b/include/souper/Infer/Pruning.h
@@ -59,6 +59,10 @@ private:
   std::vector<llvm::ConstantRange> LHSConstantRange;
   HoleAnalysis HA;
   llvm::KnownBits LHSKnownBitsNoSpec;
+
+  std::vector<llvm::KnownBits> RBInputKB;
+  std::vector<llvm::KnownBits> LHSKnownBitsForPartialRB;
+
   InputVarInfo LHSMustDemandedBits;
   bool LHSHasPhi = false;
   std::unordered_map<Inst *, ExprInfo> LHSInfo;

--- a/lib/Infer/AbstractInterpreter.cpp
+++ b/lib/Infer/AbstractInterpreter.cpp
@@ -935,13 +935,16 @@ namespace souper {
 #define RB1 findRestrictedBits(I->Ops[1])
 #define RB2 findRestrictedBits(I->Ops[2])
   llvm::APInt RestrictedBitsAnalysis::findRestrictedBits(souper::Inst *I) {
-    if (RBCache.find(I) != RBCache.end()) {
-      return RBCache[I];
-    }
-
     llvm::APInt Result(I->Width, 0);
     llvm::APInt AllZeroes = Result;
     Result.setAllBits();
+    if (RBCache.find(I) != RBCache.end()) {
+      llvm::APInt CachedResult = RBCache[I];
+      if (I->K == Inst::Var) {
+        RBCache[I] = Result; // set to all ones after 'first' use
+      }
+      return CachedResult;
+    }
 
     if (isReservedConst(I)) {
       // nop, all bits set


### PR DESCRIPTION
Makes pruning 30% faster and prunes a few percent more candidates.
Subsumes some of the slower techniques. 