### PR TITLE
Fix early termination when run build_deps.sh on OS X

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 # Copyright 2014 The Souper Authors. All rights reserved.
 #


### PR DESCRIPTION
The `sh -e` on a clean OS X behaves a little differently and it terminates on my new ncpu detection line
`ncpus=$(command nproc 2>/dev/null || command sysctl -n hw.ncpu 2>/dev/null || echo 8)`. I changed the interpreter of script from `sh`  to `bash`, since the behavior of `||` under `-e` is cleared defined as below in bash manual. After switching to bash the script is working correctly on mac os.

`
-e      Exit immediately if a simple command (see SHELL GRAMMAR above) exits with a non-zero status.  The shell *does not exit* if the command that fails is part of the command list immediately following a while or until keyword, part of the test in an if statement, *part of a && or || list*, or if the command's return value is being inverted via !.  A trap on ERR, if set, is executed before the shell exits.
`