### PR TITLE
Link Z3 dynamically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ include_directories(${Z3_INCLUDE_DIRECTORY})
 
 find_library(Z3_LIBRARY
   NAMES
-  libz3.a
+  z3
   PATHS
   third_party/z3-install/lib
   NO_DEFAULT_PATH)


### PR DESCRIPTION
Z3 is used in two places in souper's dependencies. 1) LLVM and 2)
libalive2.so. When both of these dependencies use Z3 statically, there
are two copies of z3 and it creates horrible horrible problems in
AliveDriver in souper. Let's dynamically link Z3 so that we use only one
copy of Z3 and avoid these nasty problems.