### PR TITLE
Add constant guess to enumerative synthesis

### DIFF
--- a/lib/Extractor/Solver.cpp
+++ b/lib/Extractor/Solver.cpp
@@ -389,7 +389,7 @@ public:
      * guess a few constants that are likely to be cheap for the
      * backend to make
      */
-    if (InferInts || LHS->Width == 1) {
+    if (!EnableEnumerativeSynthesis && InferInts || LHS->Width == 1) {
       std::vector<Inst *>Guesses { IC.getConst(APInt(LHS->Width, 0)),
                                    IC.getConst(APInt(LHS->Width, 1)) };
       if (LHS->Width > 1)
@@ -421,7 +421,7 @@ public:
       }
     }
 
-    if (InferInts && SMTSolver->supportsModels() && LHS->Width > 1) {
+    if (!EnableEnumerativeSynthesis && InferInts && SMTSolver->supportsModels() && LHS->Width > 1) {
       Inst *C = IC.createSynthesisConstant(LHS->Width, /*SynthesisConstID=*/1);
 
       if (UseAlive) {

--- a/lib/Infer/EnumerativeSynthesis.cpp
+++ b/lib/Infer/EnumerativeSynthesis.cpp
@@ -873,6 +873,9 @@ EnumerativeSynthesis::synthesize(SMTLIBSolver *SMTSolver,
     return true;
   };
 
+  // add constant guess
+  Guesses.push_back(IC.createSynthesisConstant(SC.LHS->Width, 1));
+
   // add nops guesses separately
   for (auto I : Cands) {
     if (I->Width == SC.LHS->Width) {


### PR DESCRIPTION
-souper-enumerative-synthesis-num-insts=0 can now synthesize a constant along with the nop guesses.