### PR TITLE
remove redundant LHS/BPCs/PCs duplication

### DIFF
--- a/test/Infer/blockpc-invalid1.opt
+++ b/test/Infer/blockpc-invalid1.opt
@@ -5,8 +5,6 @@
 
 ; CHECK: Failed to infer RHS
 
-; XFAIL: *
-
 %0 = block 2
 %1:i8 = var
 %2:i1 = ne 0:i8, %1


### PR DESCRIPTION
The use of the duplicated LHS/BPCs/PCs can be just replaced by the use of original LHS/BPCs/PCs in constant synthesis. There is no point for duplicating them and duplicating itself is triggering the issue in blockpc-invalid1.opt. This patch removes the duplication calls.