### PR TITLE
Fallback to code generating if the dominance check fails

### DIFF
--- a/lib/Codegen/Codegen.cpp
+++ b/lib/Codegen/Codegen.cpp
@@ -90,8 +90,7 @@ llvm::Value *Codegen::getValue(Inst *I) {
       }
     }
     if (DebugLevel > 2)
-      llvm::errs() << "returning nullptr from getValue()\n";
-    return nullptr;
+      llvm::errs() << "dominance check failed. falling back into code generation\n";    
   }
 
   // otherwise, recursively generate code


### PR DESCRIPTION
…to code generation

Small example to illustrate a missed optimization opportunity:

define dso_local i64 @_Z15MissingPattern4m(i64 %0) local_unnamed_addr #0 {
  %2 = xor i64 %0, -1276188105
  %3 = shl i64 %0, 1
  %4 = and i64 %3, -2552376210
  %5 = add i64 %2, 1276188121
  %6 = add i64 %5, %4
  %7 = add i64 %0, 16 ; Replacement origin that fails the dominance check
  %8 = and i64 %6, %7
  ret i64 %8
}