### PR TITLE
[NFC] Include <vector> in Verification.h.

### DIFF
--- a/utils/gen-xfer-funcs/Verification.h
+++ b/utils/gen-xfer-funcs/Verification.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <unordered_map>
 #include <memory>
+#include <vector>
 
 namespace souper {  
 using z3::expr;


### PR DESCRIPTION
Using my toolchain, none of these previously imported headers import `vector`. It seems like it makes sense to include it directly here. 