### PR TITLE
Set available=false for overflow instructions when parsing

### DIFF
--- a/lib/Infer/EnumerativeSynthesis.cpp
+++ b/lib/Infer/EnumerativeSynthesis.cpp
@@ -323,6 +323,7 @@ bool getGuesses(const std::set<Inst *> &Inputs,
 
           if ((*I)->Width == 0 && (*J)->Width == 0) {
             // TODO: support (cmp hole, hole);
+            // TODO: support (cmp hole, c) and (cmp c, hole)
             continue;
           }
 

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -1324,30 +1324,37 @@ bool Parser::parseLine(std::string &ErrStr) {
           ErrStr = makeErrStr(TP, ErrStr);
           return false;
         }
+        unsigned W = Ops[0]->Width;
         switch (IK) {
           case Inst::SAddWithOverflow:
-            I = IC.getInst(IK, InstWidth, {IC.getInst(Inst::Add, Ops[0]->Width, Ops),
-                           IC.getInst(Inst::SAddO, 1, Ops)});
+            I = IC.getInst(IK, InstWidth,
+                           {IC.getInst(Inst::Add, W, Ops, /*Available=*/false),
+                            IC.getInst(Inst::SAddO, 1, Ops, /*Available=*/false)});
             break;
           case Inst::UAddWithOverflow:
-            I = IC.getInst(IK, InstWidth, {IC.getInst(Inst::Add, Ops[0]->Width, Ops),
-                           IC.getInst(Inst::UAddO, 1, Ops)});
+            I = IC.getInst(IK, InstWidth,
+                           {IC.getInst(Inst::Add, W, Ops, /*Available=*/false),
+                            IC.getInst(Inst::UAddO, 1, Ops, /*Available=*/false)});
             break;
           case Inst::SSubWithOverflow:
-            I = IC.getInst(IK, InstWidth, {IC.getInst(Inst::Sub, Ops[0]->Width, Ops),
-                           IC.getInst(Inst::SSubO, 1, Ops)});
+            I = IC.getInst(IK, InstWidth,
+                           {IC.getInst(Inst::Sub, W, Ops, /*Available=*/false),
+                            IC.getInst(Inst::SSubO, 1, Ops, /*Available=*/false)});
             break;
           case Inst::USubWithOverflow:
-            I = IC.getInst(IK, InstWidth, {IC.getInst(Inst::Sub, Ops[0]->Width, Ops),
-                           IC.getInst(Inst::USubO, 1, Ops)});
+            I = IC.getInst(IK, InstWidth,
+                           {IC.getInst(Inst::Sub, W, Ops, /*Available=*/false),
+                            IC.getInst(Inst::USubO, 1, Ops, /*Available=*/false)});
             break;
           case Inst::SMulWithOverflow:
-            I = IC.getInst(IK, InstWidth, {IC.getInst(Inst::Mul, Ops[0]->Width, Ops),
-                           IC.getInst(Inst::SMulO, 1, Ops)});
+            I = IC.getInst(IK, InstWidth,
+                           {IC.getInst(Inst::Mul, W, Ops, /*Available=*/false),
+                            IC.getInst(Inst::SMulO, 1, Ops, /*Available=*/false)});
             break;
           case Inst::UMulWithOverflow:
-            I = IC.getInst(IK, InstWidth, {IC.getInst(Inst::Mul, Ops[0]->Width, Ops),
-                           IC.getInst(Inst::UMulO, 1, Ops)});
+            I = IC.getInst(IK, InstWidth,
+                           {IC.getInst(Inst::Mul, W, Ops, /*Available=*/false),
+                            IC.getInst(Inst::UMulO, 1, Ops, /*Available=*/false)});
             break;
           default:
             I = IC.getInst(IK, InstWidth, Ops);


### PR DESCRIPTION
Note with this patch, we still can't get the result we want for the case

```
%0:i32 = var
%1:i32 = var
%2:i33 = ssub.with.overflow %0, %1 (hasExternalUses)
%3:i32 = extractvalue %2, 0:i32 (hasExternalUses)
%4:i1 = ule %3, 31:i32
pc %4 1:i1
%5:i32 = subnw 31:i32, %3
%6:i32 = lshr 1:i32, %5
%7:i1 = eq 0:i32, %6
infer %7
%8:i32 = sub %0, %1
%9:i1 = ult %8, 31:i32
result %9
```

This is because the RHS we want has the form (cmp hole, const); the enumerator is not handling such forms since no concrete widths are available when generating the root.