### PR TITLE
Fixed two test cases

### DIFF
--- a/test/Extractor/harvest-uses.c
+++ b/test/Extractor/harvest-uses.c
@@ -6,7 +6,7 @@ int func(int x) {
   int y = x * 11;
   int z = x * 17;
   if (y == 88)
-    // CHECK: call i32 @a(i32 136)
+    // CHECK: call i32 @a(i32 noundef 136)
     return a(z);
   else
     return b(z);

--- a/test/Infer/syn-single-inst/syn-sub.opt
+++ b/test/Infer/syn-single-inst/syn-sub.opt
@@ -3,9 +3,9 @@
 ; RUN: %FileCheck %s < %t1
 ; CHECK: sub %1, %0
 
-%0:i32 = var
-%1:i32 = var
-%2:i32 = add %1, 10:i32
-%3:i32 = sub %2, 10:i32
-%4:i32 = sub %3, %0
+%0:i8 = var
+%1:i8 = var
+%2:i8 = add %1, 10:i8
+%3:i8 = sub %2, 10:i8
+%4:i8 = sub %3, %0
 infer %4


### PR DESCRIPTION
* added missed attribute that was inserted by updated LLVM to `harvest-uses.c`'s check string.
* reduced bit width to avoid timeout in Alive2 for `syn-sub.opt`. Note we'll not have any timeouts for the original case if we use the latest alive2 (https://alive2.llvm.org/ce/z/QENppr)